### PR TITLE
Make @claude responsive on PRs: allow tests, unblock push, switch to tag mode

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -48,13 +48,16 @@ jobs:
           # routes network through a proxy with a domain allowlist. `git push`
           # (and `pip install`) need the network, and in a headless CI run the
           # sandbox cannot prompt a human to escalate out — so they get denied.
-          # Allow the domains required to push branches and install deps.
+          # Matching is per-host, so list every host the workflow touches:
+          #   github.com           - git push/fetch over HTTPS
+          #   api.github.com       - the `gh` CLI (gh pr create / comment / view)
+          #   pypi.org, files.pythonhosted.org - `pip install`
           settings: |
             {
               "sandbox": {
                 "enabled": true,
                 "network": {
-                  "allowedDomains": ["github.com", "pypi.org", "files.pythonhosted.org"]
+                  "allowedDomains": ["github.com", "api.github.com", "pypi.org", "files.pythonhosted.org"]
                 }
               }
             }

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -59,24 +59,20 @@ jobs:
               }
             }
 
-          # The job-level `if:` already guarantees the requester is a trusted
-          # maintainer (OWNER / MEMBER / COLLABORATOR), so this prompt only needs
-          # to control WHEN a PR is opened: only on an explicit instruction.
-          prompt: |
-            Follow the instructions in the comment or issue that triggered this run.
-
-            By default, respond by posting your findings, answer, or a suggested
-            patch as a comment. Do NOT create branches, push commits, or open a
-            pull request unless the triggering comment EXPLICITLY instructs you to
-            do so (for example: "open a PR", "submit a PR", "fix this and open a
-            pull request", "implement and push a branch").
-
-            If the request is ambiguous about whether a PR is wanted, comment only
-            and ask for confirmation rather than opening a PR.
-
-          # Allow Claude to create branches, commit, open PRs, AND run the
-          # build/test tools it needs to validate a change before pushing.
-          # Bash is not allowed by default — only the commands listed here are
-          # permitted (this list adds to the action's built-in Edit/Write/etc.).
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(git:*),Bash(gh:*),Bash(python:*),Bash(pytest:*),Bash(pip:*),Edit,Write"'
+          # NOTE: no `prompt:` input. Setting `prompt:` forces the action into
+          # "agent mode", which runs headlessly and does NOT post a reply back to
+          # the issue/PR. Omitting it selects "tag mode", which responds to the
+          # @claude mention and manages a response comment automatically. The
+          # behavioral guidance that used to live in `prompt:` is moved into
+          # `--append-system-prompt` below so tag mode keeps it.
+          #
+          # Allowed tools let Claude edit files, run the build/test suite, commit,
+          # push, and open PRs. Bash is deny-by-default, so only the listed
+          # commands are permitted (this list adds to the built-in Edit/Write).
+          # The job-level `if:` (OWNER / MEMBER / COLLABORATOR) is what gates who
+          # can invoke Claude; the system prompt only shapes WHAT it does.
+          claude_args: |
+            --model claude-opus-4-8
+            --allowed-tools "Bash(git:*),Bash(gh:*),Bash(python:*),Bash(pytest:*),Bash(pip:*),Edit,Write"
+            --append-system-prompt "When you are triggered on an existing open pull request (via a PR review, a review comment, or an issue comment on the PR), address the feedback directly: make the code changes, run the relevant tests when code is touched, commit to that PR's branch and push, then post a comment summarizing what you changed and how you verified it. When you are triggered on an issue, only create a branch and open a new pull request if the triggering comment explicitly asks for one (for example 'open a PR' or 'implement and push a branch'); otherwise respond with your findings or a suggested patch as a comment and ask for confirmation."
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -44,6 +44,21 @@ jobs:
           additional_permissions: |
             actions: read
 
+          # The Bash tool runs inside an OS-level sandbox by default, which
+          # routes network through a proxy with a domain allowlist. `git push`
+          # (and `pip install`) need the network, and in a headless CI run the
+          # sandbox cannot prompt a human to escalate out — so they get denied.
+          # Allow the domains required to push branches and install deps.
+          settings: |
+            {
+              "sandbox": {
+                "enabled": true,
+                "network": {
+                  "allowedDomains": ["github.com", "pypi.org", "files.pythonhosted.org"]
+                }
+              }
+            }
+
           # The job-level `if:` already guarantees the requester is a trusted
           # maintainer (OWNER / MEMBER / COLLABORATOR), so this prompt only needs
           # to control WHEN a PR is opened: only on an explicit instruction.
@@ -59,6 +74,9 @@ jobs:
             If the request is ambiguous about whether a PR is wanted, comment only
             and ask for confirmation rather than opening a PR.
 
-          # Allow Claude to create branches, commit, and open PRs
-          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(git:*),Bash(gh pr:*),Bash(gh issue:*)"'
+          # Allow Claude to create branches, commit, open PRs, AND run the
+          # build/test tools it needs to validate a change before pushing.
+          # Bash is not allowed by default — only the commands listed here are
+          # permitted (this list adds to the action's built-in Edit/Write/etc.).
+          claude_args: '--model claude-opus-4-8 --allowed-tools "Bash(git:*),Bash(gh:*),Bash(python:*),Bash(pytest:*),Bash(pip:*),Edit,Write"'
 


### PR DESCRIPTION
## Why

In #116, `@claude` was asked to implement a feature and open a PR but only posted code as a comment. Following up, `@claude address codex's review` on this very PR produced **no response at all**. Investigation of the run logs showed two distinct problems, plus a third that only surfaces after merge.

### Problems

1. **Tests couldn't run / files couldn't be reliably changed.** Bash is deny-by-default in the action; the old `--allowed-tools` list only permitted `git`/`gh pr`/`gh issue`, so `pytest`/`python` were blocked (18 permission denials in the failed run). Claude declined to push unvalidated code.
2. **`git push` was sandbox-blocked.** The Bash tool runs in an OS-level sandbox that gates network by domain; `git push` needs the network and can't prompt for escalation in headless CI.
3. **The action was in "agent mode", which never replies.** Setting the `prompt:` input forces agent mode (headless, no comment posted). That's why the review request got silence. Tag mode (no `prompt:`) is what responds to `@claude`, manages a reply comment, and pushes to an open PR's branch.

> Note: events like `issue_comment` / `pull_request_review` always run the workflow from the **default branch**, so none of these fixes take effect until merged to `main`. Verification must happen via an `@claude` comment on a future PR/issue, not on this PR.

## Changes

- **Broaden `--allowed-tools`**: add `Bash(python:*)`, `Bash(pytest:*)`, `Bash(pip:*)`, explicit `Edit`/`Write`, widen `Bash(gh pr:*)` → `Bash(gh:*)`.
- **Sandbox network allowlist** via `settings`: `github.com` (push), `pypi.org` / `files.pythonhosted.org` (deps).
- **Switch to tag mode**: remove the `prompt:` input; move the behavioral guidance into `--append-system-prompt`, rewritten so that on an **open PR** Claude makes the change, runs tests, commits/pushes to the PR branch, and comments back — while only opening **new** PRs from issues when explicitly asked.

## Behavior after merge

When a trusted maintainer (OWNER/MEMBER/COLLABORATOR) mentions `@claude` on a PR review or comment, Claude will address the feedback, push commits to that PR's branch, and reply with a summary. Bot reviews (e.g. Codex, `association: none`, no `@claude`) do **not** auto-trigger, which avoids review loops — a human invokes Claude with `@claude`.

## Notes

- Network allowlist is minimal; deps from other hosts (conda channels, git submodules, bazel registries) would need their domains added, or set `{ "sandbox": { "enabled": false } }` for this trusted-gated workflow.

Addresses the tooling/behavior issues behind #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)