### PR TITLE
ci(cuda-plugin): pass docker env vars by value (fix unbound CUDA_REPO_ARCH)

### DIFF
--- a/.github/workflows/publish_cuda_plugin.yml
+++ b/.github/workflows/publish_cuda_plugin.yml
@@ -79,10 +79,16 @@ jobs:
             CUDA_REPO_ARCH=sbsa
           fi
 
+          # Pass explicit values (not the value-less `-e VAR` form, which only
+          # forwards exported variables) so the inner `set -u` script sees them.
           docker run --rm \
             -v ${{ github.workspace }}:/project \
             -w /project \
-            -e TAG -e CUDA_MAJOR -e CUDA_PKG -e CUDA_HOME_DIR -e CUDA_REPO_ARCH \
+            -e TAG="$TAG" \
+            -e CUDA_MAJOR="$CUDA_MAJOR" \
+            -e CUDA_PKG="$CUDA_PKG" \
+            -e CUDA_HOME_DIR="$CUDA_HOME_DIR" \
+            -e CUDA_REPO_ARCH="$CUDA_REPO_ARCH" \
             "$IMAGE" \
             bash -lc '
               set -euo pipefail


### PR DESCRIPTION
## Summary

Fixes the CUDA-plugin wheel workflow, which failed on every matrix cell in
[run 27664449196](https://github.com/fishjojo/pyscfad/actions/runs/27664449196)
with:

```
bash: line 7: CUDA_REPO_ARCH: unbound variable
```

## Cause

The build step assigns `TAG`, `CUDA_MAJOR`, `CUDA_PKG`, `CUDA_HOME_DIR`, and
`CUDA_REPO_ARCH` as plain (non-exported) shell variables, then forwards them to
the container with the value-less `docker run -e VAR` form. That form only
forwards variables that are **exported** into the environment, so none reached
the container. The inner `bash -lc` script runs under `set -u`, so it aborted on
its first variable reference (`${CUDA_REPO_ARCH}` in the CUDA-repo URL).

## Fix

Pass explicit values (`-e VAR="$VAR"`), which reach the container regardless of
export state. All five variables referenced inside the container are covered.

## Verification

Reproduced the exact failure and confirmed the fix with a minimal container:

```
# value-less -e + non-exported var + set -u  ->  "CUDA_REPO_ARCH: parameter not set"
# -e VAR="$VAR"                                ->  got=x86_64
```

After merge, re-dispatch the workflow to confirm green (a single cell, e.g.
x86_64 / cuda13 / py3.13, is enough for a quick check before the full matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
