### PR TITLE
fix(lint): move _cuda_plugin import to module top (C0413)

### DIFF
--- a/pyscfad/experimental/moleintor_cuint.py
+++ b/pyscfad/experimental/moleintor_cuint.py
@@ -42,6 +42,7 @@ from pyscfad.gto.moleintor_lite import (
     _aoslice_by_atom,
     _extract_coords,
 )
+from pyscfadlib._cuda_plugin import import_plugin_module
 
 if TYPE_CHECKING:
     from pyscfad.typing import ArrayLike, Array
@@ -49,7 +50,6 @@ if TYPE_CHECKING:
 
 # Load the integral module from the CUDA plugin matching jax's CUDA version
 # (pyscfad-cuda12-plugin / pyscfad-cuda13-plugin / ...).
-from pyscfadlib._cuda_plugin import import_plugin_module
 _cuint = import_plugin_module("_cuint")
 
 if _cuint:


### PR DESCRIPTION
## Summary

Fixes a pylint error introduced with the CUDA-plugin selection helper:

```
pyscfad/experimental/moleintor_cuint.py:52:0: C0413: Import "from pyscfadlib._cuda_plugin import import_plugin_module" should be placed at the top of the module (wrong-import-position)
```

The import was placed mid-module next to its use. Move it into the top-level
import block; the `_cuint = import_plugin_module("_cuint")` statement stays at
the use site.

## Verification

- `pylint` rates the file 10.00/10 (no C0413).
- The module still imports and registers the plugin's FFI targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
