### PR TITLE
ci: upgrade GitHub Actions to latest majors

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: install pyscf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,9 +17,9 @@ jobs:
         python-version: ["3.11","3.12","3.13", "3.14"]
     environment: ci
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
       - name: install pyscf
@@ -29,7 +29,7 @@ jobs:
       - name: test
         run: ./.github/workflows/run_test.sh
       - name: Upload coverage to codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v7
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.xml

--- a/.github/workflows/deploy_doc.yml
+++ b/.github/workflows/deploy_doc.yml
@@ -13,9 +13,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Python 3.11
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.11
       - name: install pyscf

--- a/.github/workflows/publish_cuda_plugin.yml
+++ b/.github/workflows/publish_cuda_plugin.yml
@@ -40,7 +40,7 @@ jobs:
             home: /usr/local/cuda-13.0
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Decide whether to build
         id: decide
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload wheel
         if: ${{ steps.decide.outputs.should_build == 'true' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cuda_plugin_${{ matrix.cuda.major }}_${{ matrix.arch }}_${{ matrix.py }}
           path: pyscfadlib/wheelhouse/*.whl
@@ -142,7 +142,7 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/publish_pyscfad.yml
+++ b/.github/workflows/publish_pyscfad.yml
@@ -20,10 +20,10 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/publish_pyscfadlib.yml
+++ b/.github/workflows/publish_pyscfadlib.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.0
@@ -38,7 +38,7 @@ jobs:
           config-file: "{package}/pyproject.toml"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw_wheels_linux_x86_64
           path: pyscfadlib/wheelhouse/*.whl
@@ -50,7 +50,7 @@ jobs:
     runs-on: ubuntu-24.04-arm
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.0
@@ -62,7 +62,7 @@ jobs:
           config-file: "{package}/pyproject.toml"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw_wheels_linux_aarch64
           path: pyscfadlib/wheelhouse/*.whl
@@ -74,7 +74,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v3.3.0
@@ -86,7 +86,7 @@ jobs:
           config-file: "{package}/pyproject.toml"
 
       - name: Upload wheels
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: cibw_wheels_macos_arm64
           path: pyscfadlib/wheelhouse/*.whl
@@ -110,7 +110,7 @@ jobs:
 
     steps:
       - name: Download wheels
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,9 +6,9 @@ jobs:
   Pylint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: 3.12
       - name: install pyscf

--- a/.github/workflows/release_github.yml
+++ b/.github/workflows/release_github.yml
@@ -6,7 +6,7 @@ jobs:
   create-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
       - name: Release Info
         run: ./.github/workflows/release_info.sh
         id: release_info


### PR DESCRIPTION
## Summary
Upgrades pinned GitHub Actions versions across all workflows to their latest majors.

| Action | Before | After |
|---|---|---|
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v7 |
| actions/checkout | v2 / v4 / v5 | v6 |
| actions/setup-python | v4 / v5 | v6 |
| codecov/codecov-action | v4 | v7 |

`upload-artifact` and `download-artifact` are bumped together since their major versions are paired.

## Notes
- **codecov-action v4→v7**: v5+ rewrote the uploader and is stricter about `CODECOV_TOKEN`; tokenless upload still works for public repos.
- **actions/create-release@v1** (`release_github.yml`) left unchanged — that action is archived/unmaintained and needs replacing (e.g. `softprops/action-gh-release`) rather than a version bump.

## Base branch
Targets `fix-moleintor-import-position` rather than `main` because the CMake version of `publish_cuda_plugin.yml` (and thus the artifact-action edits) only exists on that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)