### PR TITLE
feat(cuda): add cuda13 install path and fix plugin runtime deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,22 +14,36 @@ PySCF with Auto-differentiation
 Installation
 ------------
 
-* To install the latest release, run:
-```
-pip install pyscfad
-```
+To install the latest release, choose the command matching your hardware:
 
-* To install the CUDA compatible version, run:
-```
-pip install pyscfad[cuda12]
-```
+| Hardware                | Installation                          |
+|-------------------------|---------------------------------------|
+| CPU                     | `pip install pyscfad`                 |
+| NVIDIA GPU (CUDA 12)    | `pip install "pyscfad[cuda12]"`       |
+| NVIDIA GPU (CUDA 13)    | `pip install "pyscfad[cuda13]"`       |
 
-* To install the development version, run:
+To install the development version, run:
 ```
 pip install git+https://github.com/fishjojo/pyscfad.git
 ```
 The dependent C/C++ library `pyscfadlib` can be compiled from source following the instruction
 [here](https://fishjojo.github.io/pyscfad/getting_started/install.html#installing-pyscfadlib).
+
+### Supported platforms
+
+Prebuilt wheels are published for the following platforms:
+
+| Platform                      | CPU | NVIDIA GPU |
+|-------------------------------|-----|------------|
+| Linux, x86_64                 | yes | yes        |
+| Linux, aarch64                | yes | yes        |
+| macOS, Apple silicon (arm64)  | yes | n/a        |
+| macOS, Intel (x86_64)         | no  | n/a        |
+| Windows, x86_64               | no  | no         |
+| Windows WSL2, x86_64          | yes | yes        |
+
+On platforms without a prebuilt wheel, `pyscfadlib` can still be compiled from source
+(see the link above).
 
 
 `pyscfad` depends on

--- a/doc/source/getting_started/install.rst
+++ b/doc/source/getting_started/install.rst
@@ -14,17 +14,38 @@ Installing from PyPI
 --------------------
 
 pyscfad can be installed via pip from `PyPI <https://pypi.org/project/pyscfad/>`_.
+Choose the command matching your hardware:
 
-.. code::
+====================  =================================
+Hardware              Installation
+====================  =================================
+CPU                   ``pip install pyscfad``
+NVIDIA GPU (CUDA 12)  ``pip install "pyscfad[cuda12]"``
+NVIDIA GPU (CUDA 13)  ``pip install "pyscfad[cuda13]"``
+====================  =================================
 
-   pip install pyscfad
+The ``cuda12``/``cuda13`` extras pull in ``jax`` with the matching CUDA support and the
+``pyscfad-cuda<major>-plugin`` wheel, which interfaces with the NVIDIA cuSOLVER/cuBLAS
+libraries. Pick the extra whose CUDA major matches your driver/toolkit.
 
+Supported platforms
+--------------------
 
-To install the CUDA compatible version, run
+Prebuilt wheels are published for the following platforms:
 
-.. code::
+============================  ===  ==========
+Platform                      CPU  NVIDIA GPU
+============================  ===  ==========
+Linux, x86_64                 yes  yes
+Linux, aarch64                yes  yes
+macOS, Apple silicon (arm64)  yes  n/a
+macOS, Intel (x86_64)         no   n/a
+Windows, x86_64               no   no
+Windows WSL2, x86_64          yes  yes
+============================  ===  ==========
 
-    pip install pyscfad[cuda12]
+On platforms without a prebuilt wheel, ``pyscfadlib`` can still be compiled from source
+(see `Installing from source`_).
 
 Installing from source
 ----------------------
@@ -77,6 +98,41 @@ Or one can manually compile the C code, and then add pyscfadlib to ``PYTHONPATH`
 
     For Mac with ARM64 architectures, one needs to set the environment variable
     ``CMAKE_OSX_ARCHITECTURES=arm64``.
+
+Compiling the CUDA plugin (NVIDIA GPUs)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``pyscfad-cuda12-plugin`` / ``pyscfad-cuda13-plugin`` packages are only needed when
+running on NVIDIA GPUs. They are built with CMake and provide the ``_solver``
+(cuSOLVER) and ``_cuint`` modules.
+
+Building from source requires a CUDA toolkit on ``PATH`` whose major matches the wheel
+(CUDA 12.8+ for the cuda12 plugin, 13.x for the cuda13 plugin), together with the
+``cmake``, ``nanobind``, ``jax``, and ``build`` Python packages. From the ``pyscfadlib``
+directory:
+
+.. code::
+
+   cd $HOME/pyscfad/pyscfadlib
+   python plugins/cuda/build_plugin.py --cuda-major 13   # or --cuda-major 12
+   pip install dist/pyscfad_cuda13_plugin*.whl
+
+``build_plugin.py`` drives ``plugins/cuda/CMakeLists.txt``, which builds the nanobind
+modules and fetches the ``cuint`` kernels from GitHub. The CUDA major (default: detected
+from ``nvcc``) selects both the wheel name and the matching ``nvidia-*`` runtime
+dependencies. Device architectures default to up to ``sm_120`` for the CUDA major;
+override them with ``--cuda-arch``, e.g.
+
+.. code::
+
+   python plugins/cuda/build_plugin.py --cuda-major 12 --cuda-arch "70-real;80-real;90-real"
+
+To also install the CUDA runtime libraries (cuSOLVER, cuBLAS, etc.) from PyPI alongside
+the plugin, install the wheel with the ``with_cuda`` extra:
+
+.. code::
+
+   pip install "dist/pyscfad_cuda13_plugin*.whl[with_cuda]"
 
 Dependencies
 ------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,11 @@ cuda12 = [
   "pyscfad-cuda12-plugin[with_cuda]>=0.3.0",
 ]
 
+cuda13 = [
+  "jax[cuda13]>=0.9.1,<0.11",
+  "pyscfad-cuda13-plugin[with_cuda]>=0.3.0",
+]
+
 [project.urls]
 Homepage = "https://github.com/fishjojo/pyscfad"
 

--- a/pyscfadlib/plugins/cuda/plugin_setup.py
+++ b/pyscfadlib/plugins/cuda/plugin_setup.py
@@ -24,6 +24,22 @@ class BinaryDistribution(Distribution):
   def has_ext_modules(self):
     return True
 
+def cuda_runtime_requirements(cuda_version):
+  """PyPI requirements for the CUDA runtime libraries the modules link against.
+
+  NVIDIA changed the package naming at CUDA 13: through CUDA 12 the real
+  libraries are suffixed (``nvidia-cublas-cu12``); from CUDA 13 on the suffixed
+  packages are empty deprecation stubs and the real libraries live under the
+  unsuffixed names, with the CUDA major encoded in the package version
+  (``nvidia-cublas`` 13.x). For the unsuffixed names we therefore pin the major
+  so a cuda13 wheel cannot resolve a future cuda14 library.
+  """
+  libs = ["nvidia-cublas", "nvidia-cuda-runtime", "nvidia-cusolver",
+          "nvidia-cusparse", "nvidia-nvjitlink"]
+  if cuda_version >= 13:
+    return [f"{name}>={cuda_version},<{cuda_version + 1}" for name in libs]
+  return [f"{name}-cu{cuda_version}" for name in libs]
+
 setup(
     name=project_name,
     version=__version__,
@@ -39,13 +55,7 @@ setup(
       # The compiled modules link these (libcusolver.so.11 for cu12,
       # libcusolver.so.12 for cu13, etc.); CI ships slim wheels that resolve
       # them from these packages at runtime.
-      'with_cuda': [
-          f"nvidia-cublas-cu{cuda_version}",
-          f"nvidia-cuda-runtime-cu{cuda_version}",
-          f"nvidia-cusolver-cu{cuda_version}",
-          f"nvidia-cusparse-cu{cuda_version}",
-          f"nvidia-nvjitlink-cu{cuda_version}",
-      ],
+      'with_cuda': cuda_runtime_requirements(cuda_version),
     },
     license="Apache-2.0",
     classifiers=[


### PR DESCRIPTION
## Summary

Adds first-class CUDA 13 install support and fixes a latent bug in the CUDA plugin's runtime dependencies, plus updated install docs.

- **`pyscfad[cuda13]` extra** — `pip install "pyscfad[cuda13]"` now pulls `jax[cuda13]` and `pyscfad-cuda13-plugin[with_cuda]`, mirroring the existing `cuda12` extra.
- **Plugin runtime-deps fix** (`plugins/cuda/plugin_setup.py`) — NVIDIA changed PyPI naming at CUDA 13: the `-cu13` packages are now empty `0.0.1` deprecation stubs, and the real libraries live under the **unsuffixed** names (`nvidia-cublas`, …) with the CUDA major encoded in the package version. The `with_cuda` extra was hardcoding `nvidia-*-cu{major}`, so a standalone `pyscfad-cuda13-plugin[with_cuda]` install resolved empty stubs and **no actual CUDA libraries**. Now CUDA ≥13 uses the unsuffixed names with the major pinned (`>=13,<14`), while CUDA 12 keeps `-cu12`.
- **Docs** — README and `doc/.../install.rst` now use a hardware install table (CPU / CUDA 12 / CUDA 13) and a supported-platforms table (Linux x86_64/aarch64, macOS arm64, Windows, Windows WSL2). `install.rst` also gains a "Compiling the CUDA plugin" section.

## Notes

- The published `pyscfad-cuda13-plugin 0.3.0` still carries the broken stub deps; a new plugin release is needed for the fix to reach users, and a new `pyscfad` release for the `[cuda13]` extra to exist on PyPI.

## Test

- `cuda_runtime_requirements()` verified to emit `nvidia-*-cu12` for major 12 and pinned unsuffixed `nvidia-*>=13,<14` for major 13.
- `pip install --dry-run ".[cuda13]"` resolves the full CUDA13 stack cleanly.
- `install.rst` validated with docutils (no table/structure warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)