### PR TITLE
feat(cuda): pool cuSOLVER handles instead of per-eigh create/destroy

### DIFF
--- a/pyscfadlib/plugins/cuda/CMakeLists.txt
+++ b/pyscfadlib/plugins/cuda/CMakeLists.txt
@@ -117,6 +117,7 @@ ExternalProject_Add(cuint_ext
 nanobind_add_module(_solver STABLE_ABI
   ${PYSCFADLIB_ROOT}/pyscfadlib/cuda/solver.cc
   ${PYSCFADLIB_ROOT}/pyscfadlib/cuda/solver_kernels.cc
+  ${PYSCFADLIB_ROOT}/pyscfadlib/cuda/handle_pool.cc
 )
 target_include_directories(_solver PRIVATE
   ${PYSCFADLIB_ROOT} ${XLA_DIR} ${CUDAToolkit_INCLUDE_DIRS})

--- a/pyscfadlib/pyscfadlib/cuda/handle_pool.cc
+++ b/pyscfadlib/pyscfadlib/cuda/handle_pool.cc
@@ -1,0 +1,42 @@
+#include "pyscfadlib/cuda/handle_pool.h"
+
+#include <mutex>
+#include <stdexcept>
+#include <string>
+
+namespace pyscfad {
+namespace cuda {
+
+template <>
+SolverHandlePool::Handle SolverHandlePool::Borrow(cudaStream_t stream) {
+    SolverHandlePool* pool = Instance();
+    std::lock_guard<std::mutex> lock(pool->mu_);
+
+    cusolverDnHandle_t handle;
+    auto& free_handles = pool->handles_[stream];
+    if (free_handles.empty()) {
+        cusolverStatus_t status = cusolverDnCreate(&handle);
+        if (status != CUSOLVER_STATUS_SUCCESS) {
+            throw std::runtime_error(
+                "cusolverDnCreate failed with status " +
+                std::to_string(static_cast<int>(status)));
+        }
+    } else {
+        handle = free_handles.back();
+        free_handles.pop_back();
+    }
+
+    if (stream) {
+        cusolverStatus_t status = cusolverDnSetStream(handle, stream);
+        if (status != CUSOLVER_STATUS_SUCCESS) {
+            throw std::runtime_error(
+                "cusolverDnSetStream failed with status " +
+                std::to_string(static_cast<int>(status)));
+        }
+    }
+
+    return Handle(pool, handle, stream);
+}
+
+} // namespace cuda
+} // namespace pyscfad

--- a/pyscfadlib/pyscfadlib/cuda/handle_pool.h
+++ b/pyscfadlib/pyscfadlib/cuda/handle_pool.h
@@ -1,0 +1,110 @@
+#ifndef PYSCFADLIB_CUDA_HANDLE_POOL_H_
+#define PYSCFADLIB_CUDA_HANDLE_POOL_H_
+
+#include <map>
+#include <mutex>
+#include <vector>
+
+#include "pyscfadlib/cuda/vendor.h"
+
+namespace pyscfad {
+namespace cuda {
+
+// A thread-safe pool of cuSOLVER-style library handles, keyed by CUDA stream.
+//
+// Creating a handle (e.g. cusolverDnCreate) allocates internal host/device
+// state and is comparatively expensive, so paying it on every FFI invocation as
+// a create/destroy pair wastes time in hot loops -- notably the per-iteration
+// generalized eigensolve of an SCF. This pool amortizes that cost: a handle is
+// created on first use for a given stream and reused thereafter (it is never
+// destroyed; the handful of cached handles live for the process lifetime, which
+// also avoids tearing them down after the CUDA context is gone).
+//
+// A handle is only ever reused on the stream it was borrowed for, so the
+// in-order execution of a single CUDA stream keeps reuse safe even while
+// previously submitted (asynchronous) work is still in flight. Concurrent
+// borrows on the same stream simply create additional handles on demand.
+//
+// Mirrors jaxlib's jaxlib/gpu/handle_pool.h.
+template <typename HandleType, typename StreamType>
+class HandlePool {
+public:
+    HandlePool() = default;
+
+    // RAII wrapper around a borrowed handle; returns it to the pool when it
+    // goes out of scope.
+    class Handle {
+    public:
+        Handle() = default;
+        ~Handle() {
+            if (pool_) {
+                pool_->Return(handle_, stream_);
+            }
+        }
+
+        Handle(const Handle&) = delete;
+        Handle& operator=(const Handle&) = delete;
+
+        Handle(Handle&& other) noexcept
+            : pool_(other.pool_), handle_(other.handle_), stream_(other.stream_) {
+            other.pool_ = nullptr;
+            other.handle_ = nullptr;
+            other.stream_ = nullptr;
+        }
+        Handle& operator=(Handle&& other) noexcept {
+            if (this != &other) {
+                if (pool_) {
+                    pool_->Return(handle_, stream_);
+                }
+                pool_ = other.pool_;
+                handle_ = other.handle_;
+                stream_ = other.stream_;
+                other.pool_ = nullptr;
+                other.handle_ = nullptr;
+                other.stream_ = nullptr;
+            }
+            return *this;
+        }
+
+        HandleType get() const { return handle_; }
+
+    private:
+        friend class HandlePool<HandleType, StreamType>;
+        Handle(HandlePool<HandleType, StreamType>* pool, HandleType handle, StreamType stream)
+            : pool_(pool), handle_(handle), stream_(stream) {}
+
+        HandlePool* pool_ = nullptr;
+        HandleType handle_ = nullptr;
+        StreamType stream_ = nullptr;
+    };
+
+    // Borrows a handle bound to `stream`, creating one if none are free. Defined
+    // per handle type as an explicit specialization (handle creation is
+    // library-specific); see handle_pool.cc.
+    static Handle Borrow(StreamType stream);
+
+private:
+    // Leaked-on-purpose singleton (see class comment).
+    static HandlePool* Instance() {
+        static auto* pool = new HandlePool();
+        return pool;
+    }
+
+    void Return(HandleType handle, StreamType stream) {
+        std::lock_guard<std::mutex> lock(mu_);
+        handles_[stream].push_back(handle);
+    }
+
+    std::mutex mu_;
+    std::map<StreamType, std::vector<HandleType>> handles_;
+};
+
+using SolverHandlePool = HandlePool<cusolverDnHandle_t, cudaStream_t>;
+
+template <>
+SolverHandlePool::Handle SolverHandlePool::Borrow(cudaStream_t stream);
+
+} // namespace cuda
+} // namespace pyscfad
+
+#endif // PYSCFADLIB_CUDA_HANDLE_POOL_H_

--- a/pyscfadlib/pyscfadlib/cuda/solver_kernels.cc
+++ b/pyscfadlib/pyscfadlib/cuda/solver_kernels.cc
@@ -1,6 +1,7 @@
 #include "xla/ffi/api/ffi.h"
 #include "pyscfadlib/ffi_helpers.h"
 #include "pyscfadlib/cuda/vendor.h"
+#include "pyscfadlib/cuda/handle_pool.h"
 #include "pyscfadlib/cuda/solver_kernels.h"
 
 namespace pyscfad {
@@ -69,9 +70,7 @@ ffi::Error SygvdImpl(
 {
     int n = MaybeCastNoOverflow<int>(a_cols);
 
-    cusolverDnHandle_t handle = NULL;
-    cusolverDnCreate(&handle);
-    cusolverDnSetStream(handle, stream);
+    auto handle = SolverHandlePool::Borrow(stream);
 
     auto *a_data = static_cast<T*>(a.untyped_data());
     auto *b_data = static_cast<T*>(b.untyped_data());
@@ -95,12 +94,12 @@ ffi::Error SygvdImpl(
     cusolverEigMode_t jobz = CUSOLVER_EIG_MODE_VECTOR;
     cublasFillMode_t uplo = lower ? CUBLAS_FILL_MODE_LOWER : CUBLAS_FILL_MODE_UPPER;
 
-    int lwork = solver::SygvdBufferSize<T>(handle, itype, jobz, uplo, n);
+    int lwork = solver::SygvdBufferSize<T>(handle.get(), itype, jobz, uplo, n);
     auto *work = AllocateWorkspace<T>(scratch, lwork, "sygvd");
 
     int64_t out_step = a_cols * a_cols;
     for (int64_t i = 0; i < batch_count; ++i) {
-        solver::Sygvd<T>(handle, itype, jobz, uplo, n,
+        solver::Sygvd<T>(handle.get(), itype, jobz, uplo, n,
                          a_out_data, b_out_data, eigenvalues_data,
                          work, lwork, info_data);
         a_out_data += out_step;
@@ -109,7 +108,6 @@ ffi::Error SygvdImpl(
         ++info_data;
     }
 
-    cusolverDnDestroy(handle);
     return ffi::Error::Success();
 }
 


### PR DESCRIPTION
## Summary

The cuSOLVER `sygvd` FFI handler (`SygvdImpl` in `cuda/solver_kernels.cc`) called `cusolverDnCreate` **and** `cusolverDnDestroy` on every invocation — i.e. once per generalized `eigh`, which on GPU means once per SCF iteration (the Roothaan `FC = SCε` solve). Handle creation allocates internal host/device state, so this is wasted setup/teardown in a hot loop.

This PR adds a thread-safe handle pool so a handle is created **once per stream** and reused across calls.

## Changes

- **New `cuda/handle_pool.h`** — generic `HandlePool<HandleType, StreamType>` mirroring jaxlib's `jaxlib/gpu/handle_pool.h`:
  - Handles cached in a `std::map<stream, vector<handle>>` under a `std::mutex`, created lazily per stream and reused for the process lifetime (never destroyed — also avoids teardown after the CUDA context is gone).
  - `Borrow(stream)` returns a move-only RAII `Handle` that returns itself to the pool on scope exit; `handle.get()` yields the raw `cusolverDnHandle_t`.
  - Reuse is safe because a handle is only ever reused on the stream it was borrowed for (single-stream in-order execution covers in-flight async work); concurrent borrows on one stream just allocate extra handles on demand.
  - Exposes `SolverHandlePool`; a cuBLAS pool later is one more `Borrow` specialization.
- **New `cuda/handle_pool.cc`** — the `SolverHandlePool::Borrow` specialization (the only handle-type-specific part). Also adds cuSOLVER status checks the old path lacked: a failed `cusolverDnCreate` was previously ignored and a NULL handle used; it now throws, consistent with `AllocateWorkspace`.
- **`cuda/solver_kernels.cc`** — `SygvdImpl` borrows a pooled handle (`Borrow` also sets the stream) and uses `handle.get()`; the per-call `cusolverDnDestroy` is removed.
- **`plugins/cuda/CMakeLists.txt`** — adds `handle_pool.cc` to the `_solver` target.

## Net effect

`cusolverDnCreate`/`Destroy` now run once per stream for the process lifetime instead of once per generalized `eigh`, removing per-SCF-iteration handle overhead.

## Testing

- Both `handle_pool.cc` and `solver_kernels.cc` compile clean (`-std=c++17 -fno-strict-aliasing`) against the real CUDA 13.3 + jaxlib FFI headers (only warnings are pre-existing ones from upstream `ffi.h`/`api.h`).
- Verified link-compatibility of the explicit member-template specialization: the mangled `Borrow` symbol **defined** in `handle_pool.o` is byte-identical to the **undefined reference** in `solver_kernels.o`.
- A full plugin build + runtime exercise needs a GPU and was not run in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)