### PR TITLE
feat(cuda): opt-in cuSOLVER FP32/FP64 tensor-core emulation

### DIFF
--- a/pyscfadlib/plugins/cuda/CMakeLists.txt
+++ b/pyscfadlib/plugins/cuda/CMakeLists.txt
@@ -124,6 +124,18 @@ target_include_directories(_solver PRIVATE
 target_compile_options(_solver PRIVATE -fno-strict-aliasing)
 target_link_libraries(_solver PRIVATE CUDA::cusolver CUDA::cublas CUDA::cudart)
 
+# Opt-in cuSOLVER FP32/FP64 emulation (handle_pool.cc, gated by PYSCFADLIB_CUSOLVER_*
+# env vars). The math-mode/strategy API and FP32 BF16x9 emulation arrived in CUDA 13.0;
+# FP64 fixed-point emulation in 13.2. Gate on the toolkit version (minor matters) so older
+# toolkits and the cuda12 plugin build cleanly and treat the env vars as a no-op.
+if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.0")
+  target_compile_definitions(_solver PRIVATE PYSCFAD_HAVE_CUSOLVER_EMULATION)
+endif()
+if(CUDAToolkit_VERSION VERSION_GREATER_EQUAL "13.2")
+  target_compile_definitions(_solver PRIVATE PYSCFAD_HAVE_CUSOLVER_FP64_EMULATION)
+endif()
+message(STATUS "_solver: cuSOLVER emulation FP32>=13.0 FP64>=13.2 (toolkit ${CUDAToolkit_VERSION})")
+
 # ---------------------------------------------------------------------------
 # _cuint : custom GPU integral kernels (links the external cuint static lib)
 # ---------------------------------------------------------------------------

--- a/pyscfadlib/pyscfadlib/cuda/handle_pool.cc
+++ b/pyscfadlib/pyscfadlib/cuda/handle_pool.cc
@@ -1,11 +1,121 @@
 #include "pyscfadlib/cuda/handle_pool.h"
 
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
 #include <mutex>
 #include <stdexcept>
 #include <string>
 
 namespace pyscfad {
 namespace cuda {
+
+namespace {
+
+// Opt-in cuSOLVER FP32/FP64 emulation, configured by environment variables and applied once
+// when a pooled handle is created (see ConfigureEmulation). Parsed once and cached.
+enum class EmuStrategy { kDefault, kPerformant, kEager };
+
+struct EmuConfig {
+    bool fp32 = false;
+    bool fp64 = false;
+    EmuStrategy strategy = EmuStrategy::kDefault;
+};
+
+bool EnvTruthy(const char* v) {
+    if (!v) {
+        return false;
+    }
+    std::string s(v);
+    for (auto& c : s) {
+        c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+    }
+    return s == "1" || s == "true" || s == "on" || s == "yes";
+}
+
+const EmuConfig& EmulationConfig() {
+    static const EmuConfig cfg = [] {
+        EmuConfig c;
+        c.fp32 = EnvTruthy(std::getenv("PYSCFADLIB_CUSOLVER_FP32_EMULATION"));
+        c.fp64 = EnvTruthy(std::getenv("PYSCFADLIB_CUSOLVER_FP64_EMULATION"));
+        const char* s = std::getenv("PYSCFADLIB_CUSOLVER_EMULATION_STRATEGY");
+        std::string sv = s ? std::string(s) : "";
+        for (auto& ch : sv) {
+            ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+        }
+        c.strategy = (sv == "performant") ? EmuStrategy::kPerformant
+                   : (sv == "eager")      ? EmuStrategy::kEager
+                   : EmuStrategy::kDefault;
+        return c;
+    }();
+    return cfg;
+}
+
+void WarnOnce(const char* msg) {
+    static std::once_flag flag;
+    std::call_once(flag, [&] { std::fprintf(stderr, "[pyscfadlib] %s\n", msg); });
+}
+
+#if defined(PYSCFAD_HAVE_CUSOLVER_EMULATION)  // CUDA >= 13.0
+// Maps the version-agnostic strategy onto the CUDA enum (native values, no casting).
+cudaEmulationStrategy_t EmulationStrategy(EmuStrategy s) {
+    switch (s) {
+        case EmuStrategy::kPerformant: return CUDA_EMULATION_STRATEGY_PERFORMANT;
+        case EmuStrategy::kEager:      return CUDA_EMULATION_STRATEGY_EAGER;
+        case EmuStrategy::kDefault:    break;
+    }
+    return CUDA_EMULATION_STRATEGY_DEFAULT;
+}
+#endif
+
+// Sets the cuSOLVER math mode + emulation strategy from the cached env config, once when a
+// handle is created. The mode is dtype-independent: cuSOLVER applies each emulation only to
+// routines of the matching precision and runs the rest natively, so a single pooled handle
+// correctly serves both FP32 and FP64 solves (combined mode when both are on). Makes no API
+// calls when emulation is off, preserving the native path. Non-fatal on failure (warns once).
+void ConfigureEmulation(cusolverDnHandle_t handle) {
+#if defined(PYSCFAD_HAVE_CUSOLVER_EMULATION)  // CUDA >= 13.0: math-mode/strategy API + FP32 BF16x9
+    const EmuConfig& cfg = EmulationConfig();
+    cusolverMathMode_t mode = CUSOLVER_DEFAULT_MATH;
+    bool emulate = false;
+#if defined(PYSCFAD_HAVE_CUSOLVER_FP64_EMULATION)  // CUDA >= 13.2: FP32, FP64 and combined modes
+    if (cfg.fp32 && cfg.fp64) {
+        mode = CUSOLVER_FP32_FP64_EMULATED_MATH;
+        emulate = true;
+    } else if (cfg.fp32) {
+        mode = CUSOLVER_FP32_EMULATED_BF16X9_MATH;
+        emulate = true;
+    } else if (cfg.fp64) {
+        mode = CUSOLVER_FP64_EMULATED_FIXEDPOINT_MATH;
+        emulate = true;
+    }
+#else  // CUDA 13.0/13.1: only FP32 BF16x9 emulation exists
+    if (cfg.fp64) {
+        WarnOnce("FP64 emulation requires CUDA >= 13.2; plugin built older. Native FP64 used.");
+    }
+    if (cfg.fp32) {
+        mode = CUSOLVER_FP32_EMULATED_BF16X9_MATH;
+        emulate = true;
+    }
+#endif
+    if (emulate) {
+        if (cusolverDnSetMathMode(handle, mode) == CUSOLVER_STATUS_SUCCESS) {
+            cusolverDnSetEmulationStrategy(handle, EmulationStrategy(cfg.strategy));  // best-effort
+        } else {
+            WarnOnce("cusolverDnSetMathMode failed; emulation ignored for this handle.");
+        }
+    }
+#else  // cuda12 / CUDA < 13.0: no math-mode API
+    const EmuConfig& cfg = EmulationConfig();
+    if (cfg.fp32 || cfg.fp64) {
+        WarnOnce("PYSCFADLIB_CUSOLVER_FP32/FP64_EMULATION set, but this plugin was built "
+                 "against CUDA < 13.0; ignoring (native precision used).");
+    }
+    (void)handle;
+#endif
+}
+
+}  // namespace
 
 template <>
 SolverHandlePool::Handle SolverHandlePool::Borrow(cudaStream_t stream) {
@@ -21,6 +131,9 @@ SolverHandlePool::Handle SolverHandlePool::Borrow(cudaStream_t stream) {
                 "cusolverDnCreate failed with status " +
                 std::to_string(static_cast<int>(status)));
         }
+        // Configure emulation once, at creation: the env-driven config is process-global,
+        // so a handle later reused from the pool already carries the right math mode.
+        ConfigureEmulation(handle);
     } else {
         handle = free_handles.back();
         free_handles.pop_back();


### PR DESCRIPTION
## Summary

Adds an opt-in switch to run the cuSOLVER generalized eigensolver (`sygvd`/`hegvd`) with tensor-core float emulation, controlled entirely by environment variables read in the cuSOLVER plugin — no Python/config/call-site changes.

| Env var | Effect |
|---|---|
| `PYSCFADLIB_CUSOLVER_FP32_EMULATION` | FP32 routines → `CUSOLVER_FP32_EMULATED_BF16X9_MATH` |
| `PYSCFADLIB_CUSOLVER_FP64_EMULATION` | FP64 routines → `CUSOLVER_FP64_EMULATED_FIXEDPOINT_MATH` |
| `PYSCFADLIB_CUSOLVER_EMULATION_STRATEGY` | `default` / `performant` / `eager` |

Both toggles on → combined `CUSOLVER_FP32_FP64_EMULATED_MATH`. Truthy parsing is `1`/`true`/`on`/`yes` (case-insensitive). With the vars unset the native path is unchanged.

## Design

The emulation math mode is precision-targeted (cuSOLVER applies each mode only to routines of the matching precision and runs the rest natively) and the config is process-global, so the mode is a pure function of the env toggles — not dtype-dependent. It is therefore set once per pooled handle **at creation**, in `SolverHandlePool::Borrow`, right after `cusolverDnSetStream`. `solver_kernels.cc` and the generic `HandlePool` template are untouched.

## Version gating

`cusolverDnSetMathMode`/`SetEmulationStrategy` + FP32 BF16×9 require CUDA 13.0; FP64 fixed-point requires 13.2. Gated by CMake compile defs on `CUDAToolkit_VERSION`:
- `PYSCFAD_HAVE_CUSOLVER_EMULATION` (≥ 13.0)
- `PYSCFAD_HAVE_CUSOLVER_FP64_EMULATION` (≥ 13.2)

Older toolkits and the cuda12 plugin build cleanly and treat the env vars as a no-op (warn once).

## Verification

- Emulation symbols/enums confirmed present in CUDA 13.3 headers with the exact spelling used (`cudaEmulationStrategy_t` in `library_types.h`, reachable via `cusolverDn.h`); enum values `DEFAULT=0 / PERFORMANT=1 / EAGER=2`.
- `handle_pool.cc` syntax-checks clean under `-Wall -Wextra` in all three guard combos (≥ 13.2, 13.0/13.1, < 13.0).
- Full `_solver` target builds and links against cuSOLVER (CUDA 13.3).

⚠️ **Not yet verified on hardware:** that emulation actually engages and stays accurate — that needs **Blackwell** GPUs (the local test GPU is Turing, where cuSOLVER falls back to native). Confirm via `CUSOLVERDN_LOG_LEVEL=5` / `nsys` plus an eigenvalue comparison vs native.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
