### PR TITLE
docs(readme): add PyPI version and Python versions badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 PySCF with Auto-differentiation
 ===============================
 
+[![PyPI version](https://img.shields.io/pypi/v/pyscfad.svg)](https://pypi.org/project/pyscfad/)
+[![Python versions](https://img.shields.io/pypi/pyversions/pyscfad.svg)](https://pypi.org/project/pyscfad/)
 [![Build Status](https://github.com/fishjojo/pyscfad/workflows/CI/badge.svg)](https://github.com/fishjojo/pyscfad/actions?query=workflow%3ACI)
 [![codecov](https://codecov.io/gh/fishjojo/pyscfad/branch/main/graph/badge.svg?token=NLSWGI0PLE)](https://codecov.io/gh/fishjojo/pyscfad)
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.6960749.svg)](https://doi.org/10.5281/zenodo.6960749)


### PR DESCRIPTION
## Summary
- Add a **PyPI version** badge linking to the [pyscfad PyPI project](https://pypi.org/project/pyscfad/).
- Add a **Python versions** badge that derives supported versions dynamically from the PyPI classifiers (currently 3.11–3.14).

Both are placed at the top of the existing badge block in `README.md`, matching the existing shields.io markdown style.

## Test plan
- N/A — documentation only. Badges render via shields.io once the branch/PR is viewed on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)