### PR TITLE
fix(scipy): drop deprecated logm disp argument

### DIFF
--- a/pyscfad/_src/scipy/linalg.py
+++ b/pyscfad/_src/scipy/linalg.py
@@ -15,7 +15,7 @@
 import numpy
 import scipy
 
-def logm(A, disp=True, real=False):
+def logm(A, real=False):
     """Compute matrix logarithm.
 
     Compute the matrix logarithm ensuring that it is real
@@ -87,7 +87,7 @@ def logm(A, disp=True, real=False):
             idx += 1
 
         if not real_output:
-            return scipy.linalg.logm(A, disp=disp)
+            return scipy.linalg.logm(A)
 
         F = q @ t @ q.T
 
@@ -95,13 +95,10 @@ def logm(A, disp=True, real=False):
         errtol = 1000 * numpy.finfo("d").eps
         # TODO use a better error approximation
         errest = scipy.linalg.norm(scipy.linalg.expm(F) - A, 1) / scipy.linalg.norm(A, 1)
-        if disp:
-            if not numpy.isfinite(errest) or errest >= errtol:
-                print("logm result may be inaccurate, approximate err =", errest)
-            return F
-        else:
-            return F, errest
+        if not numpy.isfinite(errest) or errest >= errtol:
+            print("logm result may be inaccurate, approximate err =", errest)
+        return F
 
     else:
-        return scipy.linalg.logm(A, disp=disp)
+        return scipy.linalg.logm(A)
 


### PR DESCRIPTION
## Summary
`scipy.linalg.logm` no longer accepts the `disp` keyword argument. This removes `disp` from the pyscfad `logm` wrapper in `pyscfad/_src/scipy/linalg.py` and from the internal `scipy.linalg.logm(...)` calls.

The display-on-inaccuracy behavior (printing a warning when the approximate error is non-finite or exceeds the tolerance) is preserved inline, and the wrapper now always returns `F`.

## Notes
- The only internal caller, `pyscfad/lo/boys.py`, calls `logm(u, real=True)` and does not pass `disp`, so no callers need updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)