### PR TITLE
feat(xtb): cuint GPU backend for periodic GFN1-xTB lattice overlap integrals

### DIFF
--- a/examples/xtb/21-gfn1_kxtb.py
+++ b/examples/xtb/21-gfn1_kxtb.py
@@ -1,0 +1,65 @@
+"""GFN1-KXTB
+"""
+import numpy
+import jax
+from pyscf.data.nist import BOHR
+from pyscfad import numpy as np
+from pyscfad.pbc.gto import CellLite
+from pyscfad.xtb import basis as xtb_basis
+from pyscfad.xtb.param import GFN1Param
+from pyscfad.xtb.kxtb import GFN1KXTB
+from pyscfad.xtb import util
+from pyscfad.experimental.moleintor_cuint import _cuint, cuint_create_plan
+
+# Si
+numbers = [14,14]
+coords = np.array(
+    [
+        [0.00000,  0.00000,  0.00000],
+        [1.3467560987, 1.3467560987, 1.3467560987]
+    ]
+) / BOHR
+
+a = np.array([[0.0, 2.6935121974, 2.6935121974],
+              [2.6935121974, 0.0, 2.6935121974],
+              [2.6935121974, 2.6935121974, 0.0]]) / BOHR
+
+basis = xtb_basis.get_basis_filename()
+param = GFN1Param()
+
+# pre-compute static variables for jitted calculation
+# not needed in non-jitted cacluation
+cell = CellLite(numbers=numbers, coords=coords, a=a, basis=basis, precision=1e-6)
+kpts = cell.make_kpts([3,3,3])
+
+nimgs = numpy.asarray(cell.nimgs)
+print(f"lattice sum mesh: {nimgs}")
+
+ewald_eta = 0.4
+ke_cutoff = util.ke_cutoff_ewald(ewald_eta, cell.precision * cell.vol)
+ewald_mesh = numpy.asarray(cell.cutoff_to_mesh(ke_cutoff))
+print(f"ewald sum mesh: {ewald_mesh}")
+
+if _cuint:
+    print("use cuint backend for integrals")
+    cuint_plan = cuint_create_plan(cell)
+else:
+    cuint_plan = None
+
+def xtb_energy(coords, param, kpts, cuint_plan=None):
+    cell = CellLite(numbers=numbers, coords=coords, a=a, nimgs=nimgs,
+                    basis=basis, precision=1e-6, trace_coords=True,
+                    cuint_plan=cuint_plan, verbose=4)
+    mf = GFN1KXTB(cell, param=param, kpts=kpts)
+    mf.ewald_eta = ewald_eta
+    mf.ewald_mesh = ewald_mesh
+    mf.diis = "qbroyden"
+    e = mf.kernel()
+    return e
+
+gfn = jax.jit(jax.value_and_grad(xtb_energy, (0,1)))
+e, g = gfn(coords, param, kpts, cuint_plan)
+print("Nuclear Gradient:\n", g[0])
+print("Parameter Gradient:")
+print(f"Element['Si']{g[1].element['Si']}")
+print("...")

--- a/pyscfad/experimental/latintor_cuint.py
+++ b/pyscfad/experimental/latintor_cuint.py
@@ -23,7 +23,7 @@ import numpy
 import jax
 from jax.custom_derivatives import SymbolicZero
 
-from pyscf.gto.mole import ATM_SLOTS, BAS_SLOTS
+from pyscf.gto.mole import BAS_SLOTS
 
 from pyscfad import numpy as np
 from pyscfad import ops
@@ -196,10 +196,12 @@ def _lattice_intor_jvp(
             naoi, naoj = s1a.shape[-2:]
 
             aoidx = np.arange(naoi)
-            jvp = _gen_int1e_fill_jvp_r0(s1a, coords_dot, aoslices-_ao_loc[i0], aoidx[None,None,:,None])
+            jvp = _gen_int1e_fill_jvp_r0(s1a, coords_dot, aoslices-_ao_loc[i0],
+                                         aoidx[None,None,:,None])
 
             aoidx = np.arange(naoj)
-            jvp += _gen_int1e_fill_jvp_r0(-s1a, coords_dot, aoslices-_ao_loc[j0], aoidx[None,None,None,:])
+            jvp += _gen_int1e_fill_jvp_r0(-s1a, coords_dot, aoslices-_ao_loc[j0],
+                                          aoidx[None,None,None,:])
 
             tangent_out += jvp.reshape(tangent_out.shape)
 

--- a/pyscfad/experimental/latintor_cuint.py
+++ b/pyscfad/experimental/latintor_cuint.py
@@ -1,0 +1,213 @@
+# Copyright 2026 The PySCFAD Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Lattice GTO integrals using the cuint backend.
+"""
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+from functools import partial
+import numpy
+import jax
+from jax.custom_derivatives import SymbolicZero
+
+from pyscf.gto.mole import ATM_SLOTS, BAS_SLOTS
+
+from pyscfad import numpy as np
+from pyscfad import ops
+from pyscfad.gto.moleintor_lite import (
+    _aoslice_by_atom,
+    _extract_coords,
+)
+from pyscfad.gto._pyscf_moleintor import make_loc
+from pyscfad.gto._moleintor_jvp import _gen_int1e_fill_jvp_r0
+
+if TYPE_CHECKING:
+    from pyscfad.typing import ArrayLike, Array
+    from .moleintor_cuint import CuintPlan
+
+@partial(
+    ops.custom_jvp,
+    nondiff_argnames=(
+        "intor_name",
+        "Ls_mask",
+        "atm",
+        "bas",
+        "cuint_plan",
+        "shls_slice",
+        "comp",
+        "hermi",
+        "ao_loc",
+        "trace_coords",
+        "trace_basis",
+        "aoslices",
+    ),
+)
+def _lattice_intor(
+    intor_name: str,
+    Ls: ArrayLike,
+    Ls_mask: ArrayLike,
+    atm: ArrayLike,
+    bas: ArrayLike,
+    env: ArrayLike,
+    cuint_plan: CuintPlan,
+    shls_slice: tuple[int, ...] | None = None,
+    comp: int | None = None,
+    hermi: int = 0,
+    ao_loc: ArrayLike | None = None,
+    trace_coords: bool = False,
+    trace_basis: bool = False,
+    aoslices: ArrayLike | None = None, # for padding
+) -> Array:
+    bas = np.asarray(bas).reshape(-1,BAS_SLOTS)
+    nbas = bas.shape[0]
+    if shls_slice is not None and tuple(shls_slice)[:4] != (0, nbas, 0,  nbas):
+        raise NotImplementedError(
+            "Computing subblocks of integrals is not supported."
+        )
+    del bas
+
+    if hermi != 1:
+        raise NotImplementedError(
+            f"Only hermi=1 is supported, but got hermi={hermi}."
+        )
+
+    if intor_name == "int1e_ovlp_sph":
+        out = lat_overlap(atm, env, Ls, Ls_mask, cuint_plan)
+    else:
+        raise NotImplementedError(
+            "Integral {intor_name} is not supported."
+        )
+    return out
+
+def lat_overlap(
+    atm: ArrayLike,
+    env: ArrayLike,
+    Ls: ArrayLike,
+    Ls_mask: ArrayLike,
+    cuint_plan: CuintPlan,
+    deriv: int = 0,
+) -> Array:
+    atm = np.asarray(atm, dtype=np.int32)
+    env = np.asarray(env, dtype=np.float64)
+    Ls = np.asarray(Ls, dtype=np.float64).reshape(-1, 3)
+    Ls_mask = np.asarray(Ls_mask, dtype=np.int32)
+
+    n_functions = cuint_plan.n_functions
+    nL = Ls.shape[0]
+    if deriv == 0:
+        shape = (nL, n_functions, n_functions)
+        target = "cuint_lat_overlap_ffi"
+    elif deriv == 1:
+        shape = (nL, 3, n_functions, n_functions)
+        target = "cuint_lat_overlap_gradient_ffi"
+    else:
+        raise NotImplementedError
+    dtype = np.float64
+
+    call = jax.ffi.ffi_call(
+        target,
+        jax.ShapeDtypeStruct(shape, dtype),
+        # FIXME broadcast_all will tile non-mapped inputs to batched shapes,
+        # which is needed for out, but a waste for others,
+        # esp. for primitive_to_function.
+        vmap_method="broadcast_all",
+        input_output_aliases={0:0},
+    )
+
+    out = np.zeros(shape, dtype)
+
+    is_screened = cuint_plan.is_screened
+    n_primitives = cuint_plan.n_primitives
+    bas = cuint_plan.bas
+    primitive_to_function = cuint_plan.primitive_to_function
+
+    for pair in cuint_plan.pairs:
+        out = call(
+            out, pair.pair_indices, primitive_to_function,
+            atm, bas, env, Ls, Ls_mask,
+            i_angular=pair.li,
+            j_angular=pair.lj,
+            is_screened=is_screened,
+            n_pairs=pair.n_pairs,
+            n_primitives=n_primitives,
+            n_functions=n_functions,
+            atm_stride=numpy.int32(atm.size),
+            bas_stride=numpy.int32(bas.size),
+            env_stride=numpy.int32(env.size),
+            n_images=numpy.int32(nL),
+            reduce_over_images=numpy.int32(0),
+        )
+    return out
+
+def _lattice_intor_jvp(
+    intor_name, Ls_mask, atm, bas, cuint_plan,
+    shls_slice, comp, hermi, ao_loc,
+    trace_coords, trace_basis, aoslices,
+    primals, tangents,
+):
+    if not intor_name == "int1e_ovlp_sph":
+        raise NotImplementedError
+    assert hermi == 1
+
+    Ls, env = primals
+    Ls_dot, env_dot = tangents
+
+    primal_out = _lattice_intor(
+        intor_name, Ls, Ls_mask, atm, bas, env, cuint_plan,
+        shls_slice=shls_slice, comp=comp, hermi=hermi, ao_loc=ao_loc,
+        trace_coords=trace_coords, trace_basis=trace_basis, aoslices=aoslices,
+    )
+
+    tangent_out = np.zeros_like(primal_out)
+
+    if not isinstance(env_dot, SymbolicZero):
+        if trace_coords:
+            s1a = -lat_overlap(atm, env, Ls, Ls_mask, cuint_plan, deriv=1)
+            s1a = s1a.transpose(1,0,2,3)
+
+            env_dot = np.asarray(env_dot, dtype=np.float64)
+            coords_dot = _extract_coords(atm, env_dot)
+
+            if shls_slice is None:
+                nbas = len(bas)
+                shls_slice = (0, nbas, 0, nbas)
+            if ao_loc is None:
+                _ao_loc = make_loc(bas, intor_name)
+            else:
+                _ao_loc = ao_loc
+
+            i0, _, j0, _ = shls_slice[:4]
+            if aoslices is None:
+                aoslices = _aoslice_by_atom(atm, bas, _ao_loc)
+
+            naoi, naoj = s1a.shape[-2:]
+
+            aoidx = np.arange(naoi)
+            jvp = _gen_int1e_fill_jvp_r0(s1a, coords_dot, aoslices-_ao_loc[i0], aoidx[None,None,:,None])
+
+            aoidx = np.arange(naoj)
+            jvp += _gen_int1e_fill_jvp_r0(-s1a, coords_dot, aoslices-_ao_loc[j0], aoidx[None,None,None,:])
+
+            tangent_out += jvp.reshape(tangent_out.shape)
+
+        if trace_basis:
+            raise NotImplementedError("basis set parameter derivative not supported")
+
+    if not isinstance(Ls_dot, SymbolicZero):
+        raise NotImplementedError
+    return primal_out, tangent_out
+
+_lattice_intor.defjvp(_lattice_intor_jvp, symbolic_zeros=True)

--- a/pyscfad/experimental/test/test_latintor_cuint.py
+++ b/pyscfad/experimental/test/test_latintor_cuint.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The PySCFAD Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+from pyscf.data.nist import BOHR
+from pyscfad import numpy as np
+from pyscfad.pbc.gto import CellLite
+from pyscfad.pbc.tools import nimgs_to_lattice_Ls
+from pyscfad.experimental.moleintor_cuint import cuint_create_plan
+from pyscfad.lib import hermi_triu
+
+def func_norm(coords, numbers, a, basis, kmesh, cuint_plan=None):
+    cell = CellLite(numbers=numbers, coords=coords, a=a, rcut=None,
+                    basis=basis, precision=1e-6, trace_coords=True)
+    kpts = cell.make_kpts(kmesh)
+    Ls = nimgs_to_lattice_Ls(cell)
+    expkL = np.exp(1j*np.dot(kpts, Ls.T))
+
+    s1e_lat = cell.lattice_intor("int1e_ovlp", hermi=1, Ls=Ls, cuint_plan=cuint_plan)
+
+    if cuint_plan is not None:
+        h1 = np.einsum("kl,lpq->kpq", expkL, s1e_lat)
+        h1 = h1 + h1.transpose(0,2,1).conj()
+    else:
+        h1 = np.einsum("kl,lpq->kpq", expkL, s1e_lat)
+        h1 = hermi_triu(h1)
+
+    res = jax.vmap(lambda s: np.sqrt(np.sum(s*s.conj()).real))(h1)
+    return res
+
+def test_latovlp():
+    numbers = [14,14]
+    coords = np.array(
+        [
+            [0.00000,  0.00000,  0.00000],
+            [1.3467560987, 1.3467560987, 1.3467560987]
+        ]
+    ) / BOHR
+
+    a = np.array([[0.0, 2.6935121974, 2.6935121974],
+                  [2.6935121974, 0.0, 2.6935121974],
+                  [2.6935121974, 2.6935121974, 0.0]]) / BOHR
+
+    basis = "ccpvtz"
+    cell = CellLite(numbers=numbers, coords=coords, a=a, rcut=None,
+                    basis=basis, precision=1e-6, trace_coords=True)
+
+    cuint_plan = cuint_create_plan(cell)
+    kmesh = [3,2,2]
+    s0 = func_norm(coords, numbers, a, basis, kmesh)
+    s1 = func_norm(coords, numbers, a, basis, kmesh, cuint_plan)
+    assert abs(s1-s0).max() < 1e-9
+
+    g0 = jax.jacrev(func_norm)(coords, numbers, a, basis, kmesh)
+    g1 = jax.jacrev(func_norm)(coords, numbers, a, basis, kmesh, cuint_plan)
+    assert abs(g1-g0).max() < 1e-9

--- a/pyscfad/pbc/gto/_latintor.py
+++ b/pyscfad/pbc/gto/_latintor.py
@@ -38,15 +38,15 @@ from pyscfad.gto._pyscf_moleintor import (
 )
 from pyscfad.pbc.gto._pbcintor_lite import (
     _atom_coords,
-    _gen_int1e_fill_jvp_r0,
 )
+from pyscfad.gto._moleintor_jvp import _gen_int1e_fill_jvp_r0
 from pyscfadlib import libcgto_vjp as libcgto
 
 @partial(
     ops.custom_jvp,
     nondiff_argnames=(
         "intor_name",
-        "rcut",
+        "Ls_mask",
         "atm",
         "bas",
         "shls_slice",
@@ -60,8 +60,8 @@ from pyscfadlib import libcgto_vjp as libcgto
 )
 def _lattice_intor(
     intor_name: str,
-    rcut: float,
     Ls: ArrayLike,
+    Ls_mask: ArrayLike,
     atm: ArrayLike,
     bas: ArrayLike,
     env: ArrayLike,
@@ -88,19 +88,20 @@ def _lattice_intor(
     out = ops.pure_callback(
         partial(_lattice_intor_impl_cpu, intor_name),
         result_shape_dtypes,
-        rcut, Ls, atm, bas, env, shls_slice, comp, hermi, ao_loc,
+        Ls, Ls_mask, atm, bas, env, shls_slice, comp, hermi, ao_loc,
         vmap_method="sequential",
     )
     return out
 
 def _lattice_intor_impl_cpu(
-    intor_name, rcut, Ls, atm, bas, env,
+    intor_name, Ls, Ls_mask, atm, bas, env,
     shls_slice=None, comp=None, hermi=0, ao_loc=None,
 ):
     intor_name, comp = _get_intor_and_comp(intor_name, comp)
     nbas = bas.shape[0]
 
     Ls = numpy.asarray(Ls, dtype=numpy.float64, order="C").reshape(-1,3)
+    Ls_mask = numpy.asarray(Ls_mask, dtype=np.int32, order="C")
     nL = len(Ls)
 
     atm, bas, env = conc_env(atm, bas, env, atm, bas, env)
@@ -130,12 +131,6 @@ def _lattice_intor_impl_cpu(
 
     out = numpy.zeros((nL,comp,naoi,naoj), dtype=numpy.float64)
 
-    r = _atom_coords(atm, env)
-    rr = r[:,None] - r
-    dist_max = numpy.linalg.norm(rr, axis=2).max()
-    Ls_mask = numpy.linalg.norm(Ls, axis=1) < (rcut + dist_max)
-    Ls_mask = numpy.asarray(Ls_mask, dtype=bool, order="C")
-
     if hermi == 0:
         aosym = "s1"
     else:
@@ -162,7 +157,7 @@ def _lattice_intor_impl_cpu(
     return out
 
 def _gen_int1e_jvp_r0(
-    intor_a, intor_b, rcut, Ls, atm, bas, env, env_dot,
+    intor_a, intor_b, Ls, Ls_mask, atm, bas, env, env_dot,
     shls_slice, comp, hermi, ao_loc,
     trace_coords, trace_basis, aoslices=None,
 ):
@@ -173,7 +168,7 @@ def _gen_int1e_jvp_r0(
         comp = comp * 3
 
     s1a = -_lattice_intor(
-        intor_a, rcut, Ls, atm, bas, env,
+        intor_a, Ls, Ls_mask, atm, bas, env,
         shls_slice=shls_slice, comp=comp, hermi=hermi, ao_loc=ao_loc,
         trace_coords=trace_coords, trace_basis=trace_basis,
         aoslices=aoslices,
@@ -181,6 +176,7 @@ def _gen_int1e_jvp_r0(
 
     naoi, naoj = s1a.shape[-2:]
     s1a = s1a.reshape(nL,3,-1,naoi,naoj)
+    s1a = s1a.transpose(1,0,2,3,4).reshape(3,-1,naoi,naoj)
     coords_dot = _extract_coords(atm, env_dot)
 
     if shls_slice is None:
@@ -196,25 +192,26 @@ def _gen_int1e_jvp_r0(
         aoslices = _aoslice_by_atom(atm, bas, _ao_loc)
     aoidx = np.arange(naoi)
     jvp = _gen_int1e_fill_jvp_r0(s1a, coords_dot, aoslices-_ao_loc[i0],
-                                 aoidx[None,None,None,:,None])
+                                 aoidx[None,None,:,None])
 
     order_a = int1e_get_dr_order(intor_b)[0]
     s1b = -_lattice_intor(
-        intor_b, rcut, Ls, atm, bas, env,
+        intor_b, Ls, Ls_mask, atm, bas, env,
         shls_slice=shls_slice, comp=comp, hermi=hermi, ao_loc=ao_loc,
         trace_coords=trace_coords, trace_basis=trace_basis,
         aoslices=aoslices,
     )
     s1b = s1b.reshape(nL,3**order_a,3,-1,naoi,naoj)
     s1b = s1b.transpose(0,2,1,3,4,5).reshape(nL,3,-1,naoi,naoj)
+    s1b = s1b.transpose(1,0,2,3,4).reshape(3,-1,naoi,naoj)
 
     aoidx = np.arange(naoj)
     jvp += _gen_int1e_fill_jvp_r0(s1b, coords_dot, aoslices-_ao_loc[j0],
-                                  aoidx[None,None,None,None,:])
-    return jvp
+                                  aoidx[None,None,None,:])
+    return jvp.reshape(nL,-1,naoi,naoj)
 
 def _lattice_intor_jvp(
-    intor_name, rcut, atm, bas,
+    intor_name, Ls_mask, atm, bas,
     shls_slice, comp, hermi, ao_loc,
     trace_coords, trace_basis, aoslices,
     primals, tangents,
@@ -223,7 +220,7 @@ def _lattice_intor_jvp(
     Ls_dot, env_dot = tangents
 
     primal_out = _lattice_intor(
-        intor_name, rcut, Ls, atm, bas, env,
+        intor_name, Ls, Ls_mask, atm, bas, env,
         shls_slice=shls_slice, comp=comp, hermi=hermi, ao_loc=ao_loc,
         trace_coords=trace_coords, trace_basis=trace_basis, aoslices=aoslices,
     )
@@ -238,7 +235,7 @@ def _lattice_intor_jvp(
         if trace_coords and (intor_ip_bra or intor_ip_ket):
             tangent_out += _gen_int1e_jvp_r0(
                 intor_ip_bra, intor_ip_ket,
-                rcut, Ls, atm, bas, env, env_dot,
+                Ls, Ls_mask, atm, bas, env, env_dot,
                 shls_slice, comp, hermi, ao_loc,
                 trace_coords, trace_basis, aoslices,
             ).reshape(tangent_out.shape)

--- a/pyscfad/pbc/gto/_latintor.py
+++ b/pyscfad/pbc/gto/_latintor.py
@@ -36,9 +36,6 @@ from pyscfad.gto._pyscf_moleintor import (
     make_loc,
     _get_intor_and_comp,
 )
-from pyscfad.pbc.gto._pbcintor_lite import (
-    _atom_coords,
-)
 from pyscfad.gto._moleintor_jvp import _gen_int1e_fill_jvp_r0
 from pyscfadlib import libcgto_vjp as libcgto
 

--- a/pyscfad/pbc/gto/_pbcintor_lite.py
+++ b/pyscfad/pbc/gto/_pbcintor_lite.py
@@ -38,6 +38,7 @@ from pyscfad.gto._pyscf_moleintor import (
     make_loc,
     _get_intor_and_comp,
 )
+from pyscfad.gto._moleintor_jvp import _gen_int1e_fill_jvp_r0
 from pyscfadlib import libcgto_vjp as libcgto
 
 def _atom_coords(atm, env):
@@ -235,6 +236,7 @@ def _gen_int1e_jvp_r0(
 
     naoi, naoj = s1a.shape[-2:]
     s1a = s1a.reshape(nkpts,3,-1,naoi,naoj)
+    s1a = s1a.transpose(1,0,2,3,4).reshape(3,-1,naoi,naoj)
     coords_dot = _extract_coords(atm, env_dot)
 
     if shls_slice is None:
@@ -250,7 +252,7 @@ def _gen_int1e_jvp_r0(
         aoslices = _aoslice_by_atom(atm, bas, _ao_loc)
     aoidx = np.arange(naoi)
     jvp = _gen_int1e_fill_jvp_r0(s1a, coords_dot, aoslices-_ao_loc[i0],
-                                 aoidx[None,None,None,:,None])
+                                 aoidx[None,None,:,None])
 
     if hermi == 0:
         order_a = int1e_get_dr_order(intor_b)[0]
@@ -262,21 +264,14 @@ def _gen_int1e_jvp_r0(
         )
         s1b = s1b.reshape(nkpts,3**order_a,3,-1,naoi,naoj)
         s1b = s1b.transpose(0,2,1,3,4,5).reshape(nkpts,3,-1,naoi,naoj)
+        s1b = s1b.transpose(1,0,2,3,4).reshape(3,-1,naoi,naoj)
 
         aoidx = np.arange(naoj)
         jvp += _gen_int1e_fill_jvp_r0(s1b, coords_dot, aoslices-_ao_loc[j0],
-                                      aoidx[None,None,None,None,:])
+                                      aoidx[None,None,None,:])
     elif hermi == 1:
-        jvp += jvp.transpose(0,1,3,2)
-    return jvp
-
-def _gen_int1e_fill_jvp_r0(ints, coords_t, aoslices, aoidx):
-    def _fill(sl, coord_t):
-        mask = (aoidx >= sl[0]) & (aoidx < sl[1])
-        grad = np.where(mask, ints, np.array(0, dtype=ints.dtype))
-        return np.einsum("kxyij,x->kyij", grad, coord_t)
-    jvp = np.sum(ops.vmap(_fill)(aoslices, coords_t), axis=0)
-    return jvp
+        jvp += jvp.transpose(0,2,1).conj()
+    return jvp.reshape(nkpts,-1,naoi,naoj)
 
 def _pbc_intor_jvp(
     intor_name, rcut, atm, bas,

--- a/pyscfad/pbc/gto/cell_lite.py
+++ b/pyscfad/pbc/gto/cell_lite.py
@@ -19,9 +19,14 @@ from typing import TYPE_CHECKING
 
 from pyscfad import numpy as np
 from pyscfad.gto import MoleLite
-from pyscfad.pbc.gto import cell
+from pyscfad.pbc.gto import cell, _latintor
 from pyscfad.pbc.gto.cell import estimate_rcut
-from pyscfad.pbc.tools import get_lattice_Ls
+from pyscfad.pbc.tools import (
+    get_lattice_Ls,
+    nimgs_to_lattice_Ls,
+)
+from pyscfad.experimental.moleintor_cuint import CuintPlan
+from pyscfad.experimental import latintor_cuint
 
 if TYPE_CHECKING:
     from pyscfad.typing import Array, ArrayLike
@@ -65,6 +70,40 @@ class Cell(MoleLite):
             scaled_Ls = np.rint(scaled_Ls).astype(int)
             nimgs = abs(scaled_Ls).max(axis=0)
         self.nimgs = nimgs
+        self._Ls = None
+
+    @property
+    def Ls(self) -> Array:
+        if self._Ls is None:
+            if self.nimgs is None:
+                raise RuntimeError("cell.nimgs is not set")
+            self._Ls = nimgs_to_lattice_Ls(self)
+        return self._Ls
+
+    @Ls.setter
+    def Ls(self, val: ArrayLike):
+        self._Ls = np.asarray(val, dtype=np.float64).reshape(-1,3)
+
+    def get_Ls_mask(
+        self,
+        Ls: ArrayLike | None = None,
+        rcut: float | None = None
+    ) -> Array:
+        if Ls is None:
+            Ls = self.Ls
+        Ls = np.asarray(Ls, dtype=np.float64).reshape(-1,3)
+
+        if rcut is None:
+            rcut = self.rcut
+        if rcut is None:
+            raise KeyError("cell.rcut not set")
+
+        r = self.atom_coords()
+        rr = r[:,None] - r
+        dist_max = np.linalg.norm(rr, axis=2).max()
+        Ls_mask = np.linalg.norm(Ls, axis=1) < (self.rcut + dist_max)
+        Ls_mask = np.asarray(Ls_mask, dtype=np.int32)
+        return Ls_mask
 
     def lattice_vectors(self) -> Array:
         """Unit cell lattice vectors.
@@ -116,21 +155,44 @@ class Cell(MoleLite):
         hermi: int = 0,
         Ls: ArrayLike | None = None,
         shls_slice: tuple[int, ...] | None = None,
+        cuint_plan: CuintPlan | None = None,
     ) -> Array:
         """Lattice one-electron integrals.
-        """
-        from pyscfad.pbc.gto._latintor import _lattice_intor
-        if Ls is None:
-            Ls = self.get_lattice_Ls()
 
+        Notes:
+            When ``hermi=1``, the CPU backend will output the lower triangle
+            (including the diagonal); the cuint backend will output irregular blocks
+            with the diagonal blocks halved, which should be used as follows
+
+            .. code-block:: python
+
+                s1e = einsum('kl,lpq->kpq', expkL, s1e_lat)
+                s1e = s1e + s1e.transpose(0,2,1).conj()
+        """
         intor_name = self._add_suffix(intor_name)
 
-        out = _lattice_intor(
-            intor_name, self.rcut, Ls,
-            self._atm, self._bas, self._env,
-            shls_slice=shls_slice, comp=comp, hermi=hermi,
-            trace_coords=self.trace_coords, trace_basis=self.trace_basis,
-        )
+        if Ls is None:
+            Ls = self.Ls
+
+        Ls_mask = self.get_Ls_mask(Ls)
+
+        if cuint_plan is None:
+            cuint_plan = self.cuint_plan
+
+        if cuint_plan is None:
+            out = _latintor._lattice_intor(
+                intor_name, Ls, Ls_mask,
+                self._atm, self._bas, self._env,
+                shls_slice=shls_slice, comp=comp, hermi=hermi,
+                trace_coords=self.trace_coords, trace_basis=self.trace_basis,
+            )
+        else:
+            out = latintor_cuint._lattice_intor(
+                intor_name, Ls, Ls_mask,
+                self._atm, self._bas, self._env, cuint_plan,
+                shls_slice=shls_slice, comp=comp, hermi=hermi,
+                trace_coords=self.trace_coords, trace_basis=self.trace_basis,
+            )
         return out
 
     make_kpts = cell.Cell.make_kpts

--- a/pyscfad/pbc/gto/test/test_cell_lite.py
+++ b/pyscfad/pbc/gto/test/test_cell_lite.py
@@ -30,10 +30,11 @@ def test_int1e():
     )
     atom = [["Si", [0,0,0]], ["Si", [.5*l,]*3]]
 
+    kmesh = [3,3,3]
     for intor in INTOR:
 
         cell = Cell(atom=atom, basis="sto3g", a=a).build()
-        kpts = cell.make_kpts([2,2,2])
+        kpts = cell.make_kpts(kmesh)
         s1e_ref = np.asarray(cell.pbc_intor(intor, kpts=kpts))
 
         norm = np.asarray(func_norm(cell, intor, kpts))
@@ -47,12 +48,12 @@ def test_int1e():
 
         coords = np.array([[0,0,0],[.5*l,.5*l,.5*l]]) / BOHR
         cell = CellLite(numbers=[14,14], coords=coords, basis="sto3g", a=a/BOHR)
-        kpts = cell.make_kpts([2,2,2])
+        kpts = cell.make_kpts(kmesh)
         s1e = cell.pbc_intor(intor, kpts=kpts)
 
         def func(coords):
             cell = CellLite(numbers=[14,14], coords=coords, basis="sto3g", a=a/BOHR, trace_coords=True)
-            kpts = cell.make_kpts([2,2,2])
+            kpts = cell.make_kpts(kmesh)
             return func_norm(cell, intor, kpts=kpts)
         g1 = np.asarray(jax.jacrev(func)(coords))
 

--- a/pyscfad/pbc/gto/test/test_pbc_intor.py
+++ b/pyscfad/pbc/gto/test/test_pbc_intor.py
@@ -63,7 +63,7 @@ def int1e_deriv1_r0(cell, intor, kpts=None):
 
 def test_int1e_r0(get_cell):
     cell = get_cell
-    kpts = cell.make_kpts([2,2,2])
+    kpts = cell.make_kpts([3,3,3])
 
     for intor in TEST_SET:
         jac_fwd = jax.jacfwd(func_norm)(cell, intor, kpts)

--- a/pyscfad/pbc/tools/pbc.py
+++ b/pyscfad/pbc/tools/pbc.py
@@ -123,7 +123,7 @@ def nimgs_to_lattice_Ls(cell, nimgs=None, dimension=None):
 
     a = cell.lattice_vectors()
     Ls = np.dot(Ts[:,:dimension], a[:dimension])
-    return Ls
+    return Ls.reshape(-1,3)
 
 def get_lattice_Ls(cell, nimgs=None, rcut=None, dimension=None, discard=True):
     """Get the lattice translation vectors for lattice sum.

--- a/pyscfad/xtb/kxtb.py
+++ b/pyscfad/xtb/kxtb.py
@@ -26,7 +26,6 @@ from pyscfad.lib import hermi_triu
 from pyscfad.gto.mole import inter_distance
 from pyscfad.pbc.scf.khf_lite import KSCFLite
 from pyscfad.dft.rks import VXC
-from pyscfad.pbc.tools import nimgs_to_lattice_Ls
 
 from pyscfad.xtb import xtb
 from pyscfad.xtb import util
@@ -92,7 +91,7 @@ def _gamma_sr_GFN1(cell: Cell, param: GFN1MolParam, rsmooth: float = 1.0) -> Arr
     eta = 1. / (param.lgam * param.gam)
     eta = 2. / (eta[:,None] + eta[None,:])
 
-    Ls = nimgs_to_lattice_Ls(cell)
+    Ls = cell.Ls
     r, r_inv = util.r_and_inv_r(cell, Ls=Ls)
 
     i, j = util.atom_to_bas_indices_2d(cell)
@@ -118,7 +117,7 @@ def _gamma_sr_erfc(cell: Cell, param: GFN1MolParam) -> Array:
     eta = 2. / (eta[:,None] + eta[None,:])
     alpha = .5 * np.sqrt(np.pi) * eta
 
-    Ls = nimgs_to_lattice_Ls(cell)
+    Ls = cell.Ls
     r, r_inv = util.r_and_inv_r(cell, Ls=Ls)
     rcut = util.rcut_erfc_over_r(alpha, cell.precision)
 
@@ -141,7 +140,7 @@ def _gamma_ewald(
     ewald_mesh: ArrayLike | None = None
 ) -> Array:
     # 1/r
-    Ls = nimgs_to_lattice_Ls(cell)
+    Ls = cell.Ls
     r, r_inv = util.r_and_inv_r(cell, Ls=Ls)
 
     ew_eta = ewald_alpha
@@ -192,10 +191,57 @@ class KXTB(xtb.XTB, KSCFLite):
         **kwargs,
     ):
         super().__init__(cell, param=param, kpts=kpts)
+        self._s1e_lat = None
 
     @property
     def tot_electrons(self) -> Array:
         return xtb.tot_valence_electrons(self.cell, nkpts=len(self.kpts))
+
+    def get_ovlp(
+        self,
+        cell: Cell | None = None,
+        kpts: ArrayLike | None = None,
+    ) -> Array:
+        if cell is None:
+            cell = self.cell
+        if kpts is None:
+            kpts = self.kpts
+
+        Ls = cell.Ls
+        expkL = np.exp(1j*np.dot(kpts, Ls.T))
+
+        if cell is self.cell:
+            s1e_lat = self.s1e_lat
+        else:
+            s1e_lat = self.get_ovlp_lat(cell=cell, Ls=Ls)
+
+        s1e = np.einsum("kl,lpq->kpq", expkL, s1e_lat)
+
+        if cell.cuint_plan is None:
+            s1e = hermi_triu(s1e)
+        else:
+            s1e = s1e + s1e.transpose(0,2,1).conj()
+        return s1e
+
+    def get_ovlp_lat(
+        self,
+        cell: Cell | None = None,
+        Ls: ArrayLike | None = None,
+    ) -> Array:
+        if cell is None:
+            cell = self.cell
+        if Ls is None:
+            Ls = cell.Ls
+        Ls = np.asarray(Ls, dtype=np.float64).reshape(-1,3)
+
+        s1e_lat = cell.lattice_intor("int1e_ovlp", hermi=1, Ls=Ls)
+        return s1e_lat
+
+    @property
+    def s1e_lat(self) -> Array:
+        if self._s1e_lat is None:
+            self._s1e_lat = self.get_ovlp_lat()
+        return self._s1e_lat
 
     def shell_charges(
         self,
@@ -226,7 +272,7 @@ def energy_nuc_GFN1(
     zeff = param.zeff
     arep = param.arep
 
-    Ls = nimgs_to_lattice_Ls(cell)
+    Ls = cell.Ls
     r, r_inv = util.r_and_inv_r(cell, Ls=Ls)
     r_safe = np.where(r>1e-6, r, 1.0)
     rcut = util.rcut_enuc_GFN1(kf, zeff, arep, cell.precision)
@@ -300,18 +346,25 @@ class GFN1KXTB(KXTB, xtb.GFN1XTB):
         hdiag = xtb.EHT_Hdiag_GFN1(cell, param)
         mask = util.mask_atom_pairs(cell)[util.atom_to_bas_indices_2d(cell)]
 
-        Ls = nimgs_to_lattice_Ls(cell)
+        Ls = cell.Ls
         nL = len(Ls)
         h1 = np.where(np.repeat(mask[None,:,:], nL, axis=0),
                       hscale[None,:,:] * EHT_PI_GFN1(cell, param, Ls=Ls) * hdiag[None,:,:],
                       np.repeat(hdiag[None,:,:], nL, axis=0))
 
-        s1e = cell.lattice_intor("int1e_ovlp", hermi=1, Ls=Ls)
+        if cell is self.cell:
+            s1e_lat = self.s1e_lat
+        else:
+            s1e_lat = self.get_ovlp_lat(cell=cell, Ls=Ls)
 
         expkL = np.exp(1j*np.dot(kpts, Ls.T))
         i, j = util.bas_to_ao_indices_2d(cell)
-        hcore = np.einsum("kl,lpq->kpq", expkL, s1e * h1[:,i,j])
-        hcore = hermi_triu(hcore)
+        hcore = np.einsum("kl,lpq->kpq", expkL, s1e_lat * h1[:,i,j])
+
+        if cell.cuint_plan is None:
+            hcore = hermi_triu(hcore)
+        else:
+            hcore = hcore + hcore.transpose(0,2,1).conj()
         return hcore
 
     def get_veff(

--- a/pyscfad/xtb/param.py
+++ b/pyscfad/xtb/param.py
@@ -111,6 +111,26 @@ class Element(pytree.PytreeNode):
         self.dipgam = None
         self.quadgam = None
 
+    def __repr__(self):
+        return (f"(levels={self.levels}, "
+                f"slater={self.slater}, "
+                f"refocc={self.refocc}, "
+                f"shpoly={self.shpoly}, "
+                f"kcn={self.kcn}, "
+                f"gam={self.gam}, "
+                f"lgam={self.lgam}, "
+                f"gam3={self.gam3}, "
+                f"zeff={self.zeff}, "
+                f"arep={self.arep}, "
+                f"xbond={self.xbond}, "
+                f"en={self.en}, "
+                f"dkernel={self.dkernel}, "
+                f"qkernel={self.qkernel}, "
+                f"mprad={self.mprad}, "
+                f"mpvcn={self.mpvcn}, "
+                f"dipgam={self.dipgam}, "
+                f"quadgam={self.quadgam})")
+
 
 class GFN1Param(pytree.PytreeNode):
     """Selected parameters from the GFN1 parameter set

--- a/pyscfadlib/plugins/cuda/CMakeLists.txt
+++ b/pyscfadlib/plugins/cuda/CMakeLists.txt
@@ -82,34 +82,70 @@ set(PYSCFAD_PLUGIN_INSTALL_DIR "." CACHE STRING
     "Install destination (relative to CMAKE_INSTALL_PREFIX) for the .so files.")
 
 # ---------------------------------------------------------------------------
-# External cuint library (custom GPU integral kernels), fetched from GitHub and
-# built with its own CMake. The architecture list is forwarded via the standard
-# CMAKE_CUDA_ARCHITECTURES (cuint honours it as of the pinned commit).
+# External cuint library (custom GPU integral kernels).
+#
+# Default: fetched from GitHub at a pinned commit and built (static) by its own
+# CMake, with the architecture list forwarded via CMAKE_CUDA_ARCHITECTURES
+# (cuint honours it as of the pinned commit).
+#
+# Local development: set -DCUINT_ROOT=/path/to/cuint pointing at a prebuilt
+# install (containing include/cuint.h and lib/libcuint.{so,a}). The plugin then
+# links that directly and skips the GitHub fetch/build, so in-tree cuint changes
+# (e.g. new pbc kernels) are picked up. CMAKE_CUDA_ARCHITECTURES is irrelevant in
+# that case — cuint is already compiled, so it must have been built for the archs
+# you intend to run on.
 # ---------------------------------------------------------------------------
-include(ExternalProject)
-set(CUINT_COMMIT "8fb61a157357a8e030ce6766e5d507815d48fe8a")
-set(CUINT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/cuint")
-set(CUINT_INSTALL_DIR "${CUINT_PREFIX}/install")
-set(CUINT_LIBRARY "${CUINT_INSTALL_DIR}/lib/libcuint.a")
+set(CUINT_ROOT "" CACHE PATH
+    "Prebuilt cuint install (include/ and lib/) to link instead of fetching+building cuint from GitHub. Empty = default GitHub build.")
 
-# ExternalProject splits ';'-lists into separate args, so pass the architecture
-# list with an alternate separator and let ExternalProject restore the ';'.
-string(REPLACE ";" "|" CUINT_ARCH "${CMAKE_CUDA_ARCHITECTURES}")
-ExternalProject_Add(cuint_ext
-  GIT_REPOSITORY https://github.com/fishjojo/cuint.git
-  GIT_TAG ${CUINT_COMMIT}
-  PREFIX ${CUINT_PREFIX}
-  INSTALL_DIR ${CUINT_INSTALL_DIR}
-  LIST_SEPARATOR "|"
-  CMAKE_CACHE_ARGS
-    -DCMAKE_BUILD_TYPE:STRING=Release
-    -DBUILD_SHARED_LIBS:BOOL=OFF
-    -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
-    -DCMAKE_CUDA_ARCHITECTURES:STRING=${CUINT_ARCH}
-    -DCMAKE_INSTALL_LIBDIR:PATH=lib
-    -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
-  BUILD_BYPRODUCTS ${CUINT_LIBRARY}
-)
+if(CUINT_ROOT)
+  get_filename_component(CUINT_ROOT "${CUINT_ROOT}" ABSOLUTE)
+  # Locate the header and library under the install root. Search the usual
+  # install layout (include/, lib/, lib64/) plus an in-tree build/ dir and the
+  # root itself, so pointing at either a `cmake --install` prefix or a raw build
+  # tree works. NO_DEFAULT_PATH keeps it from picking up a system-wide cuint.
+  find_path(CUINT_INCLUDE_DIR NAMES cuint.h
+    PATHS "${CUINT_ROOT}/include" "${CUINT_ROOT}"
+    NO_DEFAULT_PATH)
+  find_library(CUINT_LIBRARY NAMES cuint
+    PATHS "${CUINT_ROOT}/lib" "${CUINT_ROOT}/lib64" "${CUINT_ROOT}/build" "${CUINT_ROOT}"
+    NO_DEFAULT_PATH)
+  if(NOT CUINT_INCLUDE_DIR OR NOT CUINT_LIBRARY)
+    message(FATAL_ERROR
+      "CUINT_ROOT is set to \"${CUINT_ROOT}\" but a prebuilt cuint was not found there:\n"
+      "    cuint.h        -> ${CUINT_INCLUDE_DIR}\n"
+      "    libcuint.so/.a -> ${CUINT_LIBRARY}\n"
+      "Point -DCUINT_ROOT at the cuint install ROOT containing include/cuint.h and "
+      "lib/libcuint.{so,a} (e.g. /path/to/cuint), not at its lib/ or build/ subdirectory.")
+  endif()
+  message(STATUS "cuint: using prebuilt local install ${CUINT_LIBRARY} (include ${CUINT_INCLUDE_DIR})")
+else()
+  include(ExternalProject)
+  set(CUINT_COMMIT "1f39373e2c6786a3ea548048978909b956659a18")
+  set(CUINT_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/cuint")
+  set(CUINT_INSTALL_DIR "${CUINT_PREFIX}/install")
+  set(CUINT_INCLUDE_DIR "${CUINT_INSTALL_DIR}/include")
+  set(CUINT_LIBRARY "${CUINT_INSTALL_DIR}/lib/libcuint.a")
+
+  # ExternalProject splits ';'-lists into separate args, so pass the architecture
+  # list with an alternate separator and let ExternalProject restore the ';'.
+  string(REPLACE ";" "|" CUINT_ARCH "${CMAKE_CUDA_ARCHITECTURES}")
+  ExternalProject_Add(cuint_ext
+    GIT_REPOSITORY https://github.com/fishjojo/cuint.git
+    GIT_TAG ${CUINT_COMMIT}
+    PREFIX ${CUINT_PREFIX}
+    INSTALL_DIR ${CUINT_INSTALL_DIR}
+    LIST_SEPARATOR "|"
+    CMAKE_CACHE_ARGS
+      -DCMAKE_BUILD_TYPE:STRING=Release
+      -DBUILD_SHARED_LIBS:BOOL=OFF
+      -DCMAKE_POSITION_INDEPENDENT_CODE:BOOL=ON
+      -DCMAKE_CUDA_ARCHITECTURES:STRING=${CUINT_ARCH}
+      -DCMAKE_INSTALL_LIBDIR:PATH=lib
+      -DCMAKE_INSTALL_PREFIX:PATH=<INSTALL_DIR>
+    BUILD_BYPRODUCTS ${CUINT_LIBRARY}
+  )
+endif()
 
 # ---------------------------------------------------------------------------
 # _solver : cuSOLVER generalized eigensolver
@@ -144,11 +180,24 @@ nanobind_add_module(_cuint STABLE_ABI
   ${PYSCFADLIB_ROOT}/pyscfadlib/cuint/ovlp.cc
   ${PYSCFADLIB_ROOT}/pyscfadlib/cuint/dipole.cc
   ${PYSCFADLIB_ROOT}/pyscfadlib/cuint/quadrupole.cc
+  ${PYSCFADLIB_ROOT}/pyscfadlib/cuint/latovlp.cc
 )
-add_dependencies(_cuint cuint_ext)
+if(NOT CUINT_ROOT)
+  add_dependencies(_cuint cuint_ext)
+endif()
 target_include_directories(_cuint PRIVATE
-  ${PYSCFADLIB_ROOT} ${XLA_DIR} ${CUDAToolkit_INCLUDE_DIRS} ${CUINT_INSTALL_DIR}/include)
+  ${PYSCFADLIB_ROOT} ${XLA_DIR} ${CUDAToolkit_INCLUDE_DIRS} ${CUINT_INCLUDE_DIR})
 target_compile_options(_cuint PRIVATE -fno-strict-aliasing)
 target_link_libraries(_cuint PRIVATE ${CUINT_LIBRARY} CUDA::cudart)
+
+# A prebuilt local cuint is typically a shared lib; embed its directory in the
+# RPATH so the built/installed _cuint.so finds libcuint.so without LD_LIBRARY_PATH
+# (harmless if the local cuint is static). This absolute path is for local dev
+# builds only and is not portable into a redistributable wheel.
+if(CUINT_ROOT)
+  set_target_properties(_cuint PROPERTIES
+    BUILD_RPATH "${CUINT_ROOT}/lib"
+    INSTALL_RPATH "${CUINT_ROOT}/lib")
+endif()
 
 install(TARGETS _solver _cuint LIBRARY DESTINATION ${PYSCFAD_PLUGIN_INSTALL_DIR})

--- a/pyscfadlib/plugins/cuda/build_plugin.py
+++ b/pyscfadlib/plugins/cuda/build_plugin.py
@@ -53,6 +53,10 @@ def main():
     ap.add_argument("--cuda-arch", default=None,
                     help="Override CMAKE_CUDA_ARCHITECTURES, e.g. '75-real;80-real'. "
                          "Default: up to sm_120 for the CUDA major.")
+    ap.add_argument("--cuint-root", default=None,
+                    help="Prebuilt local cuint install (with include/ and lib/) to "
+                         "link instead of fetching+building cuint from GitHub. For "
+                         "local development against in-tree cuint changes.")
     ap.add_argument("--output-path", default=str(pathlib.Path.cwd() / "dist"),
                     help="Directory the wheel is written to (default: ./dist).")
     ap.add_argument("--build-dir", default=None,
@@ -84,6 +88,8 @@ def main():
     ]
     if args.cuda_arch:
         configure.append(f"-DCMAKE_CUDA_ARCHITECTURES={args.cuda_arch}")
+    if args.cuint_root:
+        configure.append(f"-DCUINT_ROOT={pathlib.Path(args.cuint_root).resolve()}")
     run(configure)
     run(["cmake", "--build", str(build_dir), "-j", args.jobs])
     run(["cmake", "--install", str(build_dir), "--prefix", str(src_tree)])

--- a/pyscfadlib/plugins/cuda/plugin_setup.py
+++ b/pyscfadlib/plugins/cuda/plugin_setup.py
@@ -30,15 +30,30 @@ def cuda_runtime_requirements(cuda_version):
   NVIDIA changed the package naming at CUDA 13: through CUDA 12 the real
   libraries are suffixed (``nvidia-cublas-cu12``); from CUDA 13 on the suffixed
   packages are empty deprecation stubs and the real libraries live under the
-  unsuffixed names, with the CUDA major encoded in the package version
-  (``nvidia-cublas`` 13.x). For the unsuffixed names we therefore pin the major
-  so a cuda13 wheel cannot resolve a future cuda14 library.
+  unsuffixed names.
+
+  For the unsuffixed names we pin each library to the major of its version so a
+  cuda13 wheel cannot resolve a library from a newer CUDA generation. Crucially,
+  only some packages version by the CUDA major: cuBLAS / cudart / nvJitLink
+  track it (13.x), while cuSOLVER and cuSPARSE keep their own independent
+  product versioning (12.x in the CUDA 13 line) -- pinning those to the CUDA
+  major instead would request a nonexistent ``>=13`` release. ``lib_major`` maps
+  each library to the version major shipped with this CUDA release.
   """
-  libs = ["nvidia-cublas", "nvidia-cuda-runtime", "nvidia-cusolver",
-          "nvidia-cusparse", "nvidia-nvjitlink"]
-  if cuda_version >= 13:
-    return [f"{name}>={cuda_version},<{cuda_version + 1}" for name in libs]
-  return [f"{name}-cu{cuda_version}" for name in libs]
+  if cuda_version < 13:
+    libs = ["nvidia-cublas", "nvidia-cuda-runtime", "nvidia-cusolver",
+            "nvidia-cusparse", "nvidia-nvjitlink"]
+    return [f"{name}-cu{cuda_version}" for name in libs]
+
+  lib_major = {
+      "nvidia-cublas": cuda_version,
+      "nvidia-cuda-runtime": cuda_version,
+      "nvidia-nvjitlink": cuda_version,
+      # Independent product versioning; revisit for CUDA majors past 13.
+      "nvidia-cusolver": 12,
+      "nvidia-cusparse": 12,
+  }
+  return [f"{name}>={major},<{major + 1}" for name, major in lib_major.items()]
 
 setup(
     name=project_name,

--- a/pyscfadlib/pyscfadlib/cuint/cuint.cc
+++ b/pyscfadlib/pyscfadlib/cuint/cuint.cc
@@ -2,6 +2,7 @@
 #include "pyscfadlib/cuint/ovlp.h"
 #include "pyscfadlib/cuint/dipole.h"
 #include "pyscfadlib/cuint/quadrupole.h"
+#include "pyscfadlib/cuint/latovlp.h"
 
 namespace pyscfad {
 namespace cuint {
@@ -19,6 +20,9 @@ nb::dict Registrations() {
 
     dict["cuint_quadrupole_ffi"] = EncapsulateFfiHandler(QuadrupoleFfi);
     dict["cuint_quadrupole_gradient_ffi"] = EncapsulateFfiHandler(QuadrupoleGradientFfi);
+
+    dict["cuint_lat_overlap_ffi"] = EncapsulateFfiHandler(LatOverlapFfi);
+    dict["cuint_lat_overlap_gradient_ffi"] = EncapsulateFfiHandler(LatOverlapGradientFfi);
     return dict;
 }
 

--- a/pyscfadlib/pyscfadlib/cuint/latovlp.cc
+++ b/pyscfadlib/pyscfadlib/cuint/latovlp.cc
@@ -1,0 +1,152 @@
+#include "xla/ffi/api/ffi.h"
+#include "pyscfadlib/cuda/vendor.h"
+#include "pyscfadlib/ffi_helpers.h"
+#include "cuint.h"
+
+namespace pyscfad {
+namespace cuint {
+
+namespace ffi = xla::ffi;
+
+ffi::Error LatOverlapDispatch(
+    cudaStream_t stream,
+    ffi::Buffer<ffi::F64> result_in,
+    ffi::Buffer<ffi::S32> pair_indices, ffi::Buffer<ffi::S32> primitive_to_function,
+    ffi::Buffer<ffi::S32> atm, ffi::Buffer<ffi::S32> bas, ffi::Buffer<ffi::F64> env,
+    ffi::Buffer<ffi::F64> Ls, ffi::Buffer<ffi::S32> mask,
+    ffi::Result<ffi::Buffer<ffi::F64>> result_out,
+    int i_angular, int j_angular, int is_screened,
+    int n_pairs, int n_primitives, int n_functions,
+    int atm_stride, int bas_stride, int env_stride,
+    int n_images, int reduce_over_images)
+{
+  auto* result_in_data = result_in.typed_data();
+  auto* result_out_data = result_out->typed_data();
+  if (result_in_data != result_out_data) {
+    cudaMemcpyAsync(result_out_data, result_in_data, result_in.size_bytes(),
+                    cudaMemcpyDeviceToDevice, stream);
+  }
+
+  auto [nmat, nao_i, nao_j] = SplitBatch2D(result_in.dimensions());
+  auto batch_count = nmat / n_images;
+  if (nao_i != nao_j || static_cast<int>(nao_i) != n_functions) {
+    return ffi::Error::InvalidArgument(
+      "Overlap: out buffer has wrong shape.");
+  }
+  auto* pair_indices_data = pair_indices.typed_data();
+  auto* primitive_to_function_data = primitive_to_function.typed_data();
+  auto* atm_data = atm.typed_data();
+  auto* bas_data = bas.typed_data();
+  auto* env_data = env.typed_data();
+  auto* Ls_data = Ls.typed_data();
+  auto* mask_data = mask.typed_data();
+
+  pbc_overlap(stream, result_out_data, pair_indices_data, n_pairs,
+              n_primitives, primitive_to_function_data,
+              n_functions, atm_data, atm_stride,
+              bas_data, bas_stride, env_data,
+              env_stride, static_cast<int>(batch_count),
+              Ls_data, n_images, mask_data,
+              i_angular, j_angular, is_screened, reduce_over_images);
+
+  return ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+  LatOverlapFfi, LatOverlapDispatch,
+  ffi::Ffi::Bind()
+    .Ctx<ffi::PlatformStream<cudaStream_t>>()
+    .Arg<ffi::Buffer<ffi::F64>>(/*result_in*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*pair_indices*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*primitive_to_function*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*atm*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*bas*/)
+    .Arg<ffi::Buffer<ffi::F64>>(/*env*/)
+    .Arg<ffi::Buffer<ffi::F64>>(/*Ls*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*mask*/)
+    .Ret<ffi::Buffer<ffi::F64>>(/*result_out*/)
+    .Attr<int>("i_angular")
+    .Attr<int>("j_angular")
+    .Attr<int>("is_screened")
+    .Attr<int>("n_pairs")
+    .Attr<int>("n_primitives")
+    .Attr<int>("n_functions")
+    .Attr<int>("atm_stride")
+    .Attr<int>("bas_stride")
+    .Attr<int>("env_stride")
+    .Attr<int>("n_images")
+    .Attr<int>("reduce_over_images")
+);
+
+ffi::Error LatOverlapGradientDispatch(
+    cudaStream_t stream,
+    ffi::Buffer<ffi::F64> result_in,
+    ffi::Buffer<ffi::S32> pair_indices, ffi::Buffer<ffi::S32> primitive_to_function,
+    ffi::Buffer<ffi::S32> atm, ffi::Buffer<ffi::S32> bas, ffi::Buffer<ffi::F64> env,
+    ffi::Buffer<ffi::F64> Ls, ffi::Buffer<ffi::S32> mask,
+    ffi::Result<ffi::Buffer<ffi::F64>> result_out,
+    int i_angular, int j_angular, int is_screened,
+    int n_pairs, int n_primitives, int n_functions,
+    int atm_stride, int bas_stride, int env_stride,
+    int n_images, int reduce_over_images)
+{
+  auto* result_in_data = result_in.typed_data();
+  auto* result_out_data = result_out->typed_data();
+  if (result_in_data != result_out_data) {
+    cudaMemcpyAsync(result_out_data, result_in_data, result_in.size_bytes(),
+                    cudaMemcpyDeviceToDevice, stream);
+  }
+
+  auto [nmat3, nao_i, nao_j] = SplitBatch2D(result_in.dimensions());
+  auto batch_count = nmat3 / n_images / 3;
+  if (nao_i != nao_j || static_cast<int>(nao_i) != n_functions) {
+    return ffi::Error::InvalidArgument(
+      "Overlap: out buffer has wrong shape.");
+  }
+  auto* pair_indices_data = pair_indices.typed_data();
+  auto* primitive_to_function_data = primitive_to_function.typed_data();
+  auto* atm_data = atm.typed_data();
+  auto* bas_data = bas.typed_data();
+  auto* env_data = env.typed_data();
+  auto* Ls_data = Ls.typed_data();
+  auto* mask_data = mask.typed_data();
+
+  pbc_overlap_gradient(stream, result_out_data, pair_indices_data, n_pairs,
+                       n_primitives, primitive_to_function_data,
+                       n_functions, atm_data, atm_stride,
+                       bas_data, bas_stride, env_data,
+                       env_stride, static_cast<int>(batch_count),
+                       Ls_data, n_images, mask_data,
+                       i_angular, j_angular, is_screened, reduce_over_images);
+
+  return ffi::Error::Success();
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+  LatOverlapGradientFfi, LatOverlapGradientDispatch,
+  ffi::Ffi::Bind()
+    .Ctx<ffi::PlatformStream<cudaStream_t>>()
+    .Arg<ffi::Buffer<ffi::F64>>(/*result_in*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*pair_indices*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*primitive_to_function*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*atm*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*bas*/)
+    .Arg<ffi::Buffer<ffi::F64>>(/*env*/)
+    .Arg<ffi::Buffer<ffi::F64>>(/*Ls*/)
+    .Arg<ffi::Buffer<ffi::S32>>(/*mask*/)
+    .Ret<ffi::Buffer<ffi::F64>>(/*result_out*/)
+    .Attr<int>("i_angular")
+    .Attr<int>("j_angular")
+    .Attr<int>("is_screened")
+    .Attr<int>("n_pairs")
+    .Attr<int>("n_primitives")
+    .Attr<int>("n_functions")
+    .Attr<int>("atm_stride")
+    .Attr<int>("bas_stride")
+    .Attr<int>("env_stride")
+    .Attr<int>("n_images")
+    .Attr<int>("reduce_over_images")
+);
+
+} // namespace cuint
+} // namespace pyscfad

--- a/pyscfadlib/pyscfadlib/cuint/latovlp.h
+++ b/pyscfadlib/pyscfadlib/cuint/latovlp.h
@@ -1,0 +1,16 @@
+#ifndef PYSCFADLIB_CUINT_LATOVLP_H_
+#define PYSCFADLIB_CUINT_LATOVLP_H_
+
+#include "xla/ffi/api/ffi.h"
+
+namespace pyscfad {
+namespace cuint {
+
+XLA_FFI_DECLARE_HANDLER_SYMBOL(LatOverlapFfi);
+XLA_FFI_DECLARE_HANDLER_SYMBOL(LatOverlapGradientFfi);
+
+} // namespace cuint
+} // namespace pyscfad
+
+#endif
+

--- a/pyscfadlib/pyscfadlib/vjp/gto/fill_int2c_lat.c
+++ b/pyscfadlib/pyscfadlib/vjp/gto/fill_int2c_lat.c
@@ -128,7 +128,7 @@ static void sort2c_s2(double *out, double *buf,
 static int _nr2c_fill(int (*intor)(), void (*sort2c)(), double *out,
                       int comp, int nimgs, int jsh, int ish0,
                       double *buf, double *env_loc,
-                      double *Ls, bool *Ls_mask,
+                      double *Ls, int *Ls_mask,
                       int *shls_slice, int *ao_loc, CINTOpt *cintopt,
                       int *atm, int natm, int *bas, int nbas, double *env)
 {
@@ -157,7 +157,7 @@ static int _nr2c_fill(int (*intor)(), void (*sort2c)(), double *out,
         cache = buf + dmjc;
 
         for (jL = 0; jL < nimgs; jL++) {
-            if (!Ls_mask[jL]) continue;
+            if (Ls_mask[jL] == 0) continue;
 
             pbuf = buf;
             shift_bas(env_loc, env, Ls, jptrxyz, jL);
@@ -180,7 +180,7 @@ static int _nr2c_fill(int (*intor)(), void (*sort2c)(), double *out,
 
 void LATnr2c_fill_s1(int (*intor)(), double *out,
                      int comp, int nimgs, int jsh,
-                      double *buf, double *env_loc, double *Ls, bool *Ls_mask,
+                      double *buf, double *env_loc, double *Ls, int *Ls_mask,
                       int *shls_slice, int *ao_loc, CINTOpt *cintopt,
                       int *atm, int natm, int *bas, int nbas, double *env)
 {
@@ -192,7 +192,7 @@ void LATnr2c_fill_s1(int (*intor)(), double *out,
 
 void LATnr2c_fill_s2(int (*intor)(), double *out,
                      int comp, int nimgs, int jsh,
-                      double *buf, double *env_loc, double *Ls, bool *Ls_mask,
+                      double *buf, double *env_loc, double *Ls, int *Ls_mask,
                       int *shls_slice, int *ao_loc, CINTOpt *cintopt,
                       int *atm, int natm, int *bas, int nbas, double *env)
 {
@@ -203,7 +203,7 @@ void LATnr2c_fill_s2(int (*intor)(), double *out,
 
 
 void LATnr2c_drv(int (*intor)(), void (*fill)(), double *out,
-                 int comp, int nimgs, double *Ls, bool *Ls_mask,
+                 int comp, int nimgs, double *Ls, int *Ls_mask,
                  int *shls_slice, int *ao_loc, CINTOpt *cintopt,
                  int *atm, int natm, int *bas, int nbas, double *env, int nenv)
 {


### PR DESCRIPTION
## Summary

Adds a GPU (**cuint**) backend for the periodic lattice **overlap** integral and
wires it through `CellLite.lattice_intor` and the periodic GFN1-xTB mean field
(`GFN1KXTB`), so a jitted KXTB energy + nuclear/parameter gradient can run the
integral hot path on the device. The CPU lattice-integral path is refactored to
share machinery (mask handling, the `r0` JVP helper) with the new GPU path. A
small CUDA packaging fix is bundled in.

This is the periodic counterpart of the existing molecular cuint overlap/dipole/
quadrupole backend.

## Part 1 — cuint backend for KXTB

### New GPU kernels (`pyscfadlib`)
- `cuint/latovlp.{cc,h}`: two XLA FFI handlers, `LatOverlapFfi` and
  `LatOverlapGradientFfi`, wrapping cuint's `pbc_overlap` / `pbc_overlap_gradient`
  device routines (lattice-summed overlap and its nuclear gradient).
- `cuint/cuint.cc`: registers the new FFI targets `cuint_lat_overlap_ffi` and
  `cuint_lat_overlap_gradient_ffi`.
- The pinned `cuint` commit is bumped (`8fb61a15…` → `1f39373e…`) to pull in the
  new periodic kernels.

### Build system (`pyscfadlib/plugins/cuda`)
- `CMakeLists.txt`: new `-DCUINT_ROOT=/path/to/cuint` option to **link a prebuilt
  local cuint** (with `include/` + `lib/`) instead of fetching+building from
  GitHub — convenient for local development against in-tree cuint changes. Embeds
  an RPATH so a shared `libcuint.so` is found without `LD_LIBRARY_PATH` (a no-op
  for a static cuint; not portable into a redistributable wheel). Adds
  `latovlp.cc` to the `_cuint` module sources.
- `build_plugin.py`: `--cuint-root` flag forwarding to `-DCUINT_ROOT`.

### Python integral layer
- `pyscfad/experimental/latintor_cuint.py` (new): a `custom_jvp`-wrapped
  `_lattice_intor` that dispatches `int1e_ovlp` to the device via
  `jax.ffi.ffi_call` using a `CuintPlan`, looping over angular-momentum shell
  pairs. Supports `hermi=1` only and implements the nuclear-coordinate JVP via the
  `deriv=1` gradient kernel.
- `pbc/gto/cell_lite.py`: `Cell.lattice_intor` gains a `cuint_plan` argument and
  dispatches to either the CPU `_latintor` or the new `latintor_cuint` GPU path.
  Adds a lazily-cached `Ls` property (built from `nimgs`) with a setter, and a
  `get_Ls_mask` helper that builds the image mask once (moved out of the CPU
  impl). Documents the differing `hermi=1` output convention between the two
  backends (CPU returns the lower triangle; cuint returns irregular blocks with
  halved diagonal, to be folded as `S + Sᴴ`).

### xtb (`pyscfad/xtb`)
- `kxtb.py`: `KXTB` gains `get_ovlp` / `get_ovlp_lat` and a cached `s1e_lat`.
  Overlap and core-Hamiltonian assembly branch on `cell.cuint_plan` — the CPU path
  uses `hermi_triu`, the cuint path uses `S + Sᴴ` (matching the halved-diagonal
  block output). Replaces direct `nimgs_to_lattice_Ls(cell)` calls with the cached
  `cell.Ls`.
- `param.py`: adds `__repr__` to `Element` for readable parameter-gradient output.

### CPU lattice-intor refactor (kept consistent with the GPU path)
- `pbc/gto/_latintor.py`: `_lattice_intor` now takes a precomputed `Ls_mask`
  (int32) rather than deriving it from `rcut` internally; JVP reshapes updated; the
  `r0` fill helper is shared from `gto/_moleintor_jvp`.
- `pbc/gto/_pbcintor_lite.py`: drops its local copy of `_gen_int1e_fill_jvp_r0`
  (now imported), and the `hermi=1` JVP uses a conjugate transpose.
- `pyscfadlib/vjp/gto/fill_int2c_lat.c`: `Ls_mask` C type `bool *` → `int *` to
  match the int32 mask now passed from Python.
- `pbc/tools/pbc.py`: `nimgs_to_lattice_Ls` now returns `Ls.reshape(-1, 3)`.

### Example & tests
- `examples/xtb/21-gfn1_kxtb.py`: end-to-end jitted GFN1-KXTB energy + nuclear and
  parameter gradients on Si, auto-selecting the cuint backend when available.
- `experimental/test/test_latintor_cuint.py`: checks the GPU lattice overlap value
  and its `jacrev` against the CPU path (agreement `< 1e-9`).
- `pbc/gto/test/test_cell_lite.py`, `test_pbc_intor.py`: bump the test k-mesh.

## Part 2 — CUDA packaging fix (`plugin_setup.py`)

The `with_cuda` extra pinned **every** unsuffixed NVIDIA runtime library to the
CUDA major (`>=13,<14`). But only cuBLAS / cudart / nvJitLink version-track the
CUDA major; cuSOLVER and cuSPARSE keep independent product versioning (12.x in the
CUDA 13 line), so `>=13` matched no release and made the extra unsatisfiable —
surfacing as a `ResolutionImpossible` on `pip install .[cuda13]`. Each library is
now mapped to the version major actually shipped with the CUDA release.

## Notes
- The cuint backend currently supports `int1e_ovlp` with `hermi=1` only;
  subblocks and basis-parameter derivatives are not implemented. The CPU path
  remains the default when no `cuint_plan` is supplied.
- GPU paths require the matching `pyscfad-cuda{12,13}-plugin` built with the
  bumped cuint commit; CPU-only builds and behavior are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
