### PR TITLE
ci(claude): temporarily enable show_full_output for diagnostics

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -104,6 +104,12 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # TEMPORARY (diagnostic): stream the full agent transcript — including
+          # per-turn token usage and the final assistant turn — to the Actions log,
+          # so we can see exactly why/where a run stops (early-stop vs context limit).
+          # Remove after the diagnostic run.
+          show_full_output: true
+
           # The action skips bot-triggered runs by default. The auto-address-review
           # path is triggered BY the Codex review bot, so allow that bot explicitly
           # (scoped, not '*') — otherwise the run is silently skipped. Human @claude


### PR DESCRIPTION
Temporary diagnostic: stream the full agent transcript (per-turn token usage + final turn) to the Actions log to determine whether long issue-fix runs end from context-window exhaustion or the model ending its turn early. Revert after the diagnostic run.