### PR TITLE
ci(claude): Stop hook + CLAUDE.md autonomy block (fix early-stopping)

### DIFF
--- a/.claude/hooks/stop-finish.sh
+++ b/.claude/hooks/stop-finish.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Stop hook for autonomous @claude CI issue-fix runs.
+#
+# Problem it solves: deep into a long headless run the model can end its turn on
+# a status update or a statement of intent ("I'll now run the regression")
+# instead of doing the work — it applies interactive turn-taking where no human
+# is present to say "continue". This hook intercepts the stop and pushes the
+# agent to finish, with a hard cap so it can never loop forever.
+#
+# Behaviour:
+#   - Allow the stop once the agent has explicitly signalled completion via
+#       git config --local claude.fixComplete true
+#   - Otherwise block (exit 2; stderr is fed back to the model) up to MAX_NUDGES
+#     times, then allow — the workflow backstop captures whatever work exists.
+set -uo pipefail
+cat >/dev/null 2>&1 || true   # drain the hook payload on stdin
+
+# Completion signalled -> let it stop.
+if [ "$(git config --local --get claude.fixComplete 2>/dev/null || true)" = "true" ]; then
+  exit 0
+fi
+
+MAX_NUDGES=3
+COUNTER="${RUNNER_TEMP:-/tmp}/claude_stop_nudges"
+n=0
+[ -f "$COUNTER" ] && n=$(cat "$COUNTER" 2>/dev/null || echo 0)
+case "$n" in ''|*[!0-9]*) n=0 ;; esac
+if [ "$n" -ge "$MAX_NUDGES" ]; then
+  exit 0   # give up gracefully; do not loop forever
+fi
+printf '%s' "$((n + 1))" > "$COUNTER"
+
+# Block this stop and tell the model what to finish.
+echo "Autonomous CI run: no human will reply, so do NOT end your turn on a status update, a plan, or a stated intention. If any step is unfinished - the final tests/regression, committing, pushing, or opening/updating the PR - do it now with tool calls. When the whole task is genuinely complete and verified, run: git config --local claude.fixComplete true   and then stop. Do not ask permission for reversible steps." >&2
+exit 2

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -104,12 +104,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
-          # TEMPORARY (diagnostic): stream the full agent transcript — including
-          # per-turn token usage and the final assistant turn — to the Actions log,
-          # so we can see exactly why/where a run stops (early-stop vs context limit).
-          # Remove after the diagnostic run.
-          show_full_output: true
-
           # The action skips bot-triggered runs by default. The auto-address-review
           # path is triggered BY the Codex review bot, so allow that bot explicitly
           # (scoped, not '*') — otherwise the run is silently skipped. Human @claude
@@ -138,6 +132,11 @@ jobs:
               },
               "permissions": {
                 "allow": ["WebSearch", "WebFetch(domain:github.com)", "WebFetch(domain:api.github.com)", "WebFetch(domain:raw.githubusercontent.com)", "WebFetch(domain:arxiv.org)", "WebFetch(domain:docs.python.org)", "WebFetch(domain:readthedocs.io)", "WebFetch(domain:pyscf.org)", "WebFetch(domain:github.io)", "WebFetch(domain:wikipedia.org)", "WebFetch(domain:doi.org)", "WebFetch(domain:stackoverflow.com)", "WebFetch(domain:stackexchange.com)", "WebFetch(domain:chemrxiv.org)", "WebFetch(domain:semanticscholar.org)"]
+              },
+              "hooks": {
+                "Stop": [
+                  { "hooks": [ { "type": "command", "command": "bash .claude/hooks/stop-finish.sh" } ] }
+                ]
               }
             }
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -210,3 +210,25 @@ integral engine. `pyscfadlib` is versioned and released independently of `pyscfa
   `pyscfad_*_implicit_diff` config flag.
 - Use `safe_*` numpy helpers (e.g. `safe_sqrt`) where derivatives can blow up at
   singularities.
+
+## Autonomous CI runs (`@claude` issue fixer)
+
+When you run non-interactively in CI (triggered by an `@claude` mention on an issue
+or PR), you are operating **autonomously**: no human is watching in real time and no
+one will answer questions or say "continue" mid-task. A Stop hook
+(`.claude/hooks/stop-finish.sh`) enforces this, but follow it regardless:
+
+- **Never end your turn on a plan, a status update, or a statement of intent.** If
+  your last message would be "I'll now run X", "running the final regression", or
+  "next I'll push", do that work *now* with tool calls instead of ending. Before
+  ending, re-read your own final message and checklist: if anything is described but
+  not actually done, do it.
+- **Don't ask permission** for reversible actions that follow from the task (running
+  tests, committing, pushing, opening/updating a PR) — just do them.
+- **Finish everything before stopping**: implementation, the targeted tests *and*
+  any final/regression sweep you said you'd run, commit, push, and the PR. Stop only
+  when the task is genuinely complete and verified, or when you are blocked on
+  something only a human can provide.
+- **Signal completion** as your very last action, once everything above is truly done
+  and verified: run `git config --local claude.fixComplete true`, then stop. This is
+  what releases the Stop hook.


### PR DESCRIPTION
Verified root cause of #136's incomplete runs: the agent ends its turn voluntarily (`stop_reason: end_turn`) on a statement of intent, with context only ~33% of the 1M window and no compaction/cap — interactive turn-taking applied in a headless run. Not a context limit.

**Fix (loop engineering):**
- `.claude/hooks/stop-finish.sh` — a Stop hook that blocks the agent from ending while work is pending (exit 2 + reason), capped at 3 nudges so it can never loop forever; allows the stop once the agent signals completion via `git config --local claude.fixComplete true`. Registered via the action's `settings` input.
- `CLAUDE.md` — an 'Autonomous CI runs' block (re-injected every request → survives compaction).
- Revert the temporary `show_full_output` flag.

Backstop remains the final net. Validated: `bash -n` + functional test (blocks without flag, allows with flag); YAML + settings JSON valid; `hooks.Stop` registered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)