### PR TITLE
ci(claude): make the agent open the PR (claude[bot]), not the fallback bot

### DIFF
--- a/.claude/hooks/stop-finish.sh
+++ b/.claude/hooks/stop-finish.sh
@@ -1,35 +1,56 @@
 #!/usr/bin/env bash
 # Stop hook for autonomous @claude CI issue-fix runs.
 #
-# Problem it solves: deep into a long headless run the model can end its turn on
-# a status update or a statement of intent ("I'll now run the regression")
-# instead of doing the work — it applies interactive turn-taking where no human
-# is present to say "continue". This hook intercepts the stop and pushes the
-# agent to finish, with a hard cap so it can never loop forever.
+# Two jobs:
+#   1. Stop the agent from ending early. Deep into a long headless run it can
+#      quit on a status update / "I'll now run X" because it applies interactive
+#      turn-taking where no human is present to say "continue".
+#   2. Make the AGENT open the pull request itself, so the PR is authored by the
+#      Claude GitHub App (claude[bot] / app/claude) — the agent's own gh identity
+#      — and NOT by the workflow's fallback step, which can only use the default
+#      Actions token (github-actions[bot]).
 #
-# Behaviour:
-#   - Allow the stop once the agent has explicitly signalled completion via
-#       git config --local claude.fixComplete true
-#   - Otherwise block (exit 2; stderr is fed back to the model) up to MAX_NUDGES
-#     times, then allow — the workflow backstop captures whatever work exists.
+# Mechanism: block the stop (exit 2; stderr is fed back to the model) until a PR
+# exists for the current branch, with a hard nudge cap so it can never loop
+# forever. The PR check is read-only (works with whatever token gh has); the PR
+# *creation* is done by the agent, whose gh authenticates as the Claude App. If
+# gh cannot answer, fall back to an explicit completion flag
+# (git config --local claude.fixComplete true). After the cap, allow the stop and
+# let the workflow backstop capture whatever exists.
 set -uo pipefail
 cat >/dev/null 2>&1 || true   # drain the hook payload on stdin
 
-# Completion signalled -> let it stop.
-if [ "$(git config --local --get claude.fixComplete 2>/dev/null || true)" = "true" ]; then
-  exit 0
-fi
-
-MAX_NUDGES=3
+MAX_NUDGES=4
 COUNTER="${RUNNER_TEMP:-/tmp}/claude_stop_nudges"
 n=0
 [ -f "$COUNTER" ] && n=$(cat "$COUNTER" 2>/dev/null || echo 0)
 case "$n" in ''|*[!0-9]*) n=0 ;; esac
-if [ "$n" -ge "$MAX_NUDGES" ]; then
-  exit 0   # give up gracefully; do not loop forever
-fi
-printf '%s' "$((n + 1))" > "$COUNTER"
 
-# Block this stop and tell the model what to finish.
-echo "Autonomous CI run: no human will reply, so do NOT end your turn on a status update, a plan, or a stated intention. If any step is unfinished - the final tests/regression, committing, pushing, or opening/updating the PR - do it now with tool calls. When the whole task is genuinely complete and verified, run: git config --local claude.fixComplete true   and then stop. Do not ask permission for reversible steps." >&2
-exit 2
+block() {  # $1 = reason fed back to the model
+  [ "$n" -ge "$MAX_NUDGES" ] && exit 0       # bounded: give up; the backstop catches it
+  printf '%s' "$((n + 1))" > "$COUNTER"
+  printf '%s\n' "$1" >&2
+  exit 2
+}
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
+
+# Preferred gate: a PR must exist for this branch, opened by the agent itself
+# (gh pr create --draft -> authored by the Claude app). Read-only existence check.
+pr_count=""
+if [ -n "$branch" ] && [ "$branch" != "main" ] && [ "$branch" != "HEAD" ]; then
+  pr_count=$(gh pr list --head "$branch" --state open --json number --jq 'length' 2>/dev/null || echo "")
+fi
+
+if [ -n "$pr_count" ] && [ "$pr_count" != "0" ]; then
+  exit 0   # you opened the PR -> allow the stop
+fi
+if [ "$pr_count" = "0" ]; then
+  block "Autonomous CI run: you have NOT opened the pull request yet. Open it YOURSELF now: finish any remaining work (final tests/regression, commit, push), then run  gh pr create --draft  so the PR is authored by you (the Claude app). Do NOT just post a 'Create a PR' link, and do NOT leave PR creation to the fallback bot. Then stop."
+fi
+
+# gh could not answer (unavailable/unauthenticated) -> fall back to a completion flag.
+if [ "$(git config --local --get claude.fixComplete 2>/dev/null || true)" = "true" ]; then
+  exit 0
+fi
+block "Autonomous CI run: do not end your turn on a status update or statement of intent. Finish all remaining work, open the draft PR yourself with  gh pr create --draft  (so it is authored by you, the Claude app), then run  git config --local claude.fixComplete true  and stop."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,6 +229,12 @@ one will answer questions or say "continue" mid-task. A Stop hook
   any final/regression sweep you said you'd run, commit, push, and the PR. Stop only
   when the task is genuinely complete and verified, or when you are blocked on
   something only a human can provide.
+- **Open the PR yourself.** When the work is ready, run `gh pr create --draft`
+  yourself so the PR is authored by **you (the Claude GitHub App)** — *not* the
+  workflow's fallback step, which can only use the default Actions token
+  (`github-actions[bot]`). Do **not** merely post a "Create a PR" link. The Stop
+  hook keeps nudging you until a PR exists for your branch, so opening it is not
+  optional.
 - **Signal completion** as your very last action, once everything above is truly done
-  and verified: run `git config --local claude.fixComplete true`, then stop. This is
-  what releases the Stop hook.
+  and verified (PR opened): run `git config --local claude.fixComplete true`, then
+  stop. This is the fallback signal the Stop hook honors when it cannot see your PR.


### PR DESCRIPTION
**Why #124 was clean but recent PRs aren't:** the old flow let the *agent* open the PR, and the agent's gh authenticates as the Claude GitHub App → `app/claude` (#124). For the large #136 task the agent early-stopped before `gh pr create`, so the backstop I added created the PR with the default Actions token → `github-actions[bot]`. That backstop was the authorship regression.

**Fix:** the Stop hook now blocks the agent from ending its turn until a PR exists for its branch, so the agent opens it itself (`gh pr create --draft` → `app/claude`). Capped at 4 nudges; falls back to the completion flag if gh can't answer in the hook; the backstop stays only as a true last-resort fallback. CLAUDE.md updated to tell the agent to open the PR itself.

Verified: allow iff a PR exists, else block; graceful gh fallback; bounded nudge cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)