### PR TITLE
xtb: FP32 working precision for kxtb and kxtb_pad

### DIFF
--- a/pyscfad/backend/numpy.py
+++ b/pyscfad/backend/numpy.py
@@ -21,6 +21,11 @@ import numpy
 #: ``x.astype(np.floatx)``.
 floatx = numpy.dtype(default_floatx())
 
+#: Complex counterpart of :data:`floatx` (``complex64`` for ``float32``,
+#: ``complex128`` for ``float64``). Use it for k-point/phase arithmetic,
+#: e.g. ``dm.astype(np.complexx)``.
+complexx = numpy.dtype(numpy.result_type(floatx, numpy.complex64))
+
 def __getattr__(name):
     return getattr(get_backend(), name)
 

--- a/pyscfad/ml/xtb/kxtb_pad.py
+++ b/pyscfad/ml/xtb/kxtb_pad.py
@@ -142,7 +142,7 @@ class GFN1KXTB(kxtb.GFN1KXTB, KXTB):
         ne_safe = np.where(ne > 1e-12, ne, 1.0)
         scale = np.where(ne > 1e-12, nelectron / ne_safe, 0.0)
         dm_kpts = dm_kpts * scale
-        return dm_kpts.astype(np.complex128)
+        return dm_kpts.astype(np.complexx)
 
     def get_hcore(
         self,
@@ -178,13 +178,14 @@ class GFN1KXTB(kxtb.GFN1KXTB, KXTB):
         shl_mask = self.cell.shl_mask
         shl_pair_mask = np.outer(shl_mask, shl_mask)
         h1 = np.where(shl_pair_mask[None, ...], h1, 0.0)
+        h1 = np.asarray(h1, dtype=np.floatx)
 
         if cell is self.cell:
             s1e_lat = self.s1e_lat
         else:
             s1e_lat = self.get_ovlp_lat(cell=cell, Ls=Ls)
 
-        expkL = np.exp(1j * np.dot(kpts, Ls.T))
+        expkL = np.exp(1j * np.dot(kpts, Ls.T)).astype(np.complexx)
         i, j = util.bas_to_ao_indices_2d(cell)
         hcore = np.einsum("kl,lpq->kpq", expkL, s1e_lat * h1[:, i, j])
 

--- a/pyscfad/pbc/gto/cell_lite.py
+++ b/pyscfad/pbc/gto/cell_lite.py
@@ -57,7 +57,7 @@ class Cell(MoleLite):
         **kwargs,
     ):
         super().__init__(**kwargs)
-        self.a = np.asarray(a, dtype=float).reshape(3,3)
+        self.a = np.asarray(a, dtype=np.floatx).reshape(3,3)
         self.precision = precision
         self.dimension = dimension
 
@@ -82,7 +82,7 @@ class Cell(MoleLite):
 
     @Ls.setter
     def Ls(self, val: ArrayLike):
-        self._Ls = np.asarray(val, dtype=np.float64).reshape(-1,3)
+        self._Ls = np.asarray(val, dtype=np.floatx).reshape(-1,3)
 
     def get_Ls_mask(
         self,

--- a/pyscfad/pbc/scf/khf_lite.py
+++ b/pyscfad/pbc/scf/khf_lite.py
@@ -56,7 +56,8 @@ def get_occ(
         mo_occ_kpts = mo_occ[inverse_idx].reshape(nkpts,-1)
     else:
         pick = (np.cumsum(mask) <= nocc) & mask
-        mo_occ = np.where(pick, 2., 0.)
+        mo_occ = np.zeros_like(pick, dtype=np.floatx)
+        mo_occ = np.where(pick, 2, mo_occ)
         mo_occ_kpts = mo_occ[inverse_idx].reshape(nkpts,-1)
 
         if mf.verbose >= logger.DEBUG:
@@ -86,7 +87,7 @@ class KSCF(SCFLite):
     ):
         if kpts is None:
             kpts = np.zeros((1,3))
-        self.kpts = np.asarray(kpts, dtype=float).reshape(-1,3)
+        self.kpts = np.asarray(kpts, dtype=np.floatx).reshape(-1,3)
 
         super().__init__(cell, **kwargs)
 

--- a/pyscfad/scf/anderson.py
+++ b/pyscfad/scf/anderson.py
@@ -81,7 +81,9 @@ def update_history(
 ) -> tuple[Any, Any, Array]:
     param_hist = _tree_set(param_hist, pos, param)
     res_hist = _tree_set(res_hist, pos, residual)
-    new_row = jax.vmap(_tree_vdot, in_axes=(0, None))(res_hist, residual)
+    # the mixing coefficients are real, so only the real part of the
+    # Gram matrix is needed (complex residuals arise with k-points)
+    new_row = jax.vmap(_tree_vdot, in_axes=(0, None))(res_hist, residual).real
     res_gram = res_gram.at[pos,:].set(new_row)
     res_gram = res_gram.at[:,pos].set(new_row)
     return param_hist, res_hist, res_gram

--- a/pyscfad/xtb/kxtb.py
+++ b/pyscfad/xtb/kxtb.py
@@ -71,7 +71,7 @@ def mulliken_charge(
     weights = 1. / nkpts
 
     PS = np.einsum("kpq,kqp->p", dm, s1e).real
-    occs = np.zeros(cell.nbas)
+    occs = np.zeros(cell.nbas, dtype=PS.dtype)
     occs = ops.index_add(occs, ops.index[util.bas_to_ao_indices(cell)], PS)
     occs *= weights
     return param.refocc - occs
@@ -98,7 +98,9 @@ def _gamma_sr_GFN1(cell: Cell, param: GFN1MolParam, rsmooth: float = 1.0) -> Arr
     r = r[:,i,j]
     r_inv = r_inv[:,i,j]
 
-    rcut = cell.rcut
+    # the cutoff radius may be a strongly-typed float64 scalar
+    # (e.g. from estimate_rcut); keep the lattice sum in working precision
+    rcut = np.asarray(cell.rcut, dtype=np.floatx)
     _val = np.sqrt(1./(r**2 + 1./eta**2)) - r_inv
     r1 = r - (rcut - rsmooth)
     x = r1 / rsmooth
@@ -131,7 +133,7 @@ def _gamma_sr_erfc(cell: Cell, param: GFN1MolParam) -> Array:
         0,
     )
     gamma = np.sum(gamma_latt, axis=0)
-    gamma += np.eye(cell.natm)[i,j] * eta
+    gamma += np.eye(cell.natm, dtype=np.floatx)[i,j] * eta
     return gamma
 
 def _gamma_ewald(
@@ -154,7 +156,7 @@ def _gamma_ewald(
     gamma = np.sum(gamma_latt, axis=0)
 
     # self energy
-    gamma += np.eye(cell.natm) * (-2 * ew_eta / np.sqrt(np.pi))
+    gamma += np.eye(cell.natm, dtype=np.floatx) * (-2 * ew_eta / np.sqrt(np.pi))
 
     if ewald_mesh is None:
         ke_cutoff = util.ke_cutoff_ewald(
@@ -208,7 +210,7 @@ class KXTB(xtb.XTB, KSCFLite):
             kpts = self.kpts
 
         Ls = cell.Ls
-        expkL = np.exp(1j*np.dot(kpts, Ls.T))
+        expkL = np.exp(1j*np.dot(kpts, Ls.T)).astype(np.complexx)
 
         if cell is self.cell:
             s1e_lat = self.s1e_lat
@@ -234,8 +236,9 @@ class KXTB(xtb.XTB, KSCFLite):
             Ls = cell.Ls
         Ls = np.asarray(Ls, dtype=np.float64).reshape(-1,3)
 
+        # the integrals are evaluated in FP64; cast to the working precision
         s1e_lat = cell.lattice_intor("int1e_ovlp", hermi=1, Ls=Ls)
-        return s1e_lat
+        return s1e_lat.astype(np.floatx)
 
     @property
     def s1e_lat(self) -> Array:
@@ -323,7 +326,7 @@ class GFN1KXTB(KXTB, xtb.GFN1XTB):
         ne = np.einsum("kij,kji->", dm_kpts, s1e).real
         nelectron = self.tot_electrons
         dm_kpts *= (nelectron / ne).reshape(-1,1,1)
-        return dm_kpts.astype(np.complex128)
+        return dm_kpts.astype(np.complexx)
 
     def get_hcore(
         self,
@@ -351,13 +354,14 @@ class GFN1KXTB(KXTB, xtb.GFN1XTB):
         h1 = np.where(np.repeat(mask[None,:,:], nL, axis=0),
                       hscale[None,:,:] * EHT_PI_GFN1(cell, param, Ls=Ls) * hdiag[None,:,:],
                       np.repeat(hdiag[None,:,:], nL, axis=0))
+        h1 = np.asarray(h1, dtype=np.floatx)
 
         if cell is self.cell:
             s1e_lat = self.s1e_lat
         else:
             s1e_lat = self.get_ovlp_lat(cell=cell, Ls=Ls)
 
-        expkL = np.exp(1j*np.dot(kpts, Ls.T))
+        expkL = np.exp(1j*np.dot(kpts, Ls.T)).astype(np.complexx)
         i, j = util.bas_to_ao_indices_2d(cell)
         hcore = np.einsum("kl,lpq->kpq", expkL, s1e_lat * h1[:,i,j])
 

--- a/tests/test_floatx.py
+++ b/tests/test_floatx.py
@@ -33,3 +33,15 @@ def test_astype_floatx():
     other = numpy.float32 if np.floatx == numpy.float64 else numpy.float64
     a = np.zeros(2, dtype=other).astype(np.floatx)
     assert a.dtype == np.floatx
+
+
+def test_complexx_dtype():
+    if np.floatx == numpy.dtype('float32'):
+        assert np.complexx == numpy.dtype('complex64')
+    else:
+        assert np.complexx == numpy.dtype('complex128')
+    # complexx is the complex counterpart of floatx
+    assert numpy.dtype(numpy.result_type(np.floatx, numpy.complex64)) == np.complexx
+    a = np.zeros(2, dtype=np.floatx).astype(np.complexx)
+    assert a.dtype == np.complexx
+    assert a.real.dtype == np.floatx

--- a/tests/xtb/test_kxtb.py
+++ b/tests/xtb/test_kxtb.py
@@ -152,6 +152,88 @@ def test_gfn1_kxtb_lattice_gradient(setup):
         fd = (cell_energy(np.asarray(ap)) - cell_energy(np.asarray(am))) / (2*h)
         assert abs(g_ad[i, j] - fd) < 1e-6 * max(abs(fd), 1.0)
 
+# Body executed under PYSCFAD_FLOATX=float32 in a subprocess (see the
+# ``run_fp32`` fixture). Runs the k-point SCF energy/force for every system in
+# ``IN`` and emits the results keyed by the system name; the parent compares
+# them against the FP64 references. Both reference structures have vanishing
+# forces by symmetry.
+_FP32_KXTB_BODY = """
+from pyscfad.pbc.gto import CellLite as Cell
+from pyscfad.xtb.kxtb import GFN1KXTB
+from pyscfad.xtb import basis as xtb_basis
+from pyscfad.xtb.param import GFN1Param
+
+basis = xtb_basis.get_basis_filename()
+param = GFN1Param()
+
+out = {}
+for name, sys in IN.items():
+    numbers = sys["numbers"]
+    coords = np.asarray(sys["coords"])
+    a = np.asarray(sys["a"])
+    sigma = sys["sigma"]
+
+    def energy(coords, numbers=numbers, a=a, sigma=sigma):
+        cell = Cell(numbers=numbers, coords=coords, a=a,
+                    basis=basis, precision=1e-6, trace_coords=True)
+        mf = GFN1KXTB(cell, param=param, kpts=cell.make_kpts([2,]*3))
+        mf.sigma = sigma
+        mf.diis = "anderson"
+        mf.diis_damp = .5
+        mf.diis_space = 6
+        mf.conv_tol = 1e-5
+        return mf.kernel()
+
+    e, g = jax.value_and_grad(energy)(coords)
+    out[name] = {"e": float(e), "g": numpy.asarray(g).tolist()}
+
+emit(**out)
+"""
+
+def test_gfn1_kxtb_energy_force_fp32(run_fp32):
+    # Si diamond (insulator, no smearing) and Cu (with Fermi smearing);
+    # FP64 references from test_gfn1_kxtb_energy_force_with_kpts_sample and
+    # test_gfn1_kxtb_smearing.
+    systems = {
+        "si": {
+            "numbers": [14, 14],
+            "coords": (np.asarray([[0.0, 0.0, 0.0],
+                                   [1.3467560987]*3]) / BOHR),
+            "a": (np.asarray([[0.0, 2.6935121974, 2.6935121974],
+                              [2.6935121974, 0.0, 2.6935121974],
+                              [2.6935121974, 2.6935121974, 0.0]]) / BOHR),
+            "sigma": None,
+            "e0": -3.83117442207487,
+        },
+        "cu": {
+            "numbers": [29, 29],
+            "coords": np.asarray(
+                [[0.        , 0.        , 0.        ],
+                 [2.40522868, 2.40522868, 3.40150702],]),
+            "a": np.asarray(
+                [[4.81045737, 0.        , 0.        ],
+                 [0.        , 4.81045737, 0.        ],
+                 [0.        , 0.        , 6.80301405],]),
+            "sigma": 0.001,
+            "e0": -9.22283523848542,
+        },
+    }
+
+    out = run_fp32(
+        _FP32_KXTB_BODY,
+        **{name: {"numbers": sys["numbers"], "coords": sys["coords"],
+                  "a": sys["a"], "sigma": sys["sigma"]}
+           for name, sys in systems.items()},
+    )
+
+    for name, sys in systems.items():
+        e0 = sys["e0"]
+        e1 = out[name]["e"]
+        g1 = np.asarray(out[name]["g"])
+        assert abs(e1 - e0) / abs(e0) < 1e-6
+        # forces vanish by symmetry; float32 resolves them to ~1e-4
+        assert abs(g1).max() < 1e-3
+
 def test_gfn1_kxtb_smearing(setup):
     basis, param = setup
     numbers = [29, 29]

--- a/tests/xtb/test_kxtb_pad.py
+++ b/tests/xtb/test_kxtb_pad.py
@@ -115,33 +115,45 @@ def _ref(bfile, nimgs, ewald_mesh, scaled_kpts, numbers, coords, a):
     return float(e), bands, path_bands
 
 
-def test_gfn1_kxtb_pad_energy_force_bands(setup):
+@pytest.fixture(scope="module")
+def refs(setup):
+    """Unbatched FP64 references shared by the FP64 and FP32 tests."""
     bfile, basis, param, nimgs, Ts, ewald_mesh, scaled_kpts = setup
-    nbas = basis.nbas
-    nk = len(scaled_kpts)
-
-    refs = [
+    return [
         _ref(bfile, nimgs, ewald_mesh, scaled_kpts, list(zs), coords, a)
         for zs, coords, a in SYSTEMS
     ]
 
-    def pad(arr, fill=0):
-        arr = numpy.asarray(arr)
-        out = numpy.full((NATM,) + arr.shape[1:], float(fill))
-        out[: len(arr)] = arr
-        return out
 
-    # batch: 2-atom Si + 4-atom C supercell + 1-atom Ne + an empty cell
+def _pad(arr, fill=0):
+    arr = numpy.asarray(arr)
+    out = numpy.full((NATM,) + arr.shape[1:], float(fill))
+    out[: len(arr)] = arr
+    return out
+
+
+def _make_batch(scaled_kpts):
+    """Batch: 2-atom Si + 4-atom C supercell + 1-atom Ne + an empty cell."""
     numbers = np.asarray(
-        [pad(zs).astype(int) for zs, _, _ in SYSTEMS]
+        [_pad(zs).astype(int) for zs, _, _ in SYSTEMS]
         + [numpy.zeros(NATM, dtype=int)],
         dtype=np.int32,
     )
     coords = np.asarray(
-        [pad(c) for _, c, _ in SYSTEMS] + [numpy.zeros((NATM, 3))]
+        [_pad(c) for _, c, _ in SYSTEMS] + [numpy.zeros((NATM, 3))]
     )
     a_batch = np.asarray([a for *_, a in SYSTEMS] + [numpy.eye(3)])
     kpts = np.asarray([_abs_kpts(scaled_kpts, a) for a in a_batch])
+    kpts_band = np.asarray([_abs_kpts(SCALED_BAND_PATH, a) for a in a_batch])
+    return numbers, coords, a_batch, kpts, kpts_band
+
+
+def test_gfn1_kxtb_pad_energy_force_bands(setup, refs):
+    bfile, basis, param, nimgs, Ts, ewald_mesh, scaled_kpts = setup
+    nbas = basis.nbas
+    nk = len(scaled_kpts)
+
+    numbers, coords, a_batch, kpts, kpts_band = _make_batch(scaled_kpts)
     n_solids = len(SYSTEMS)
 
     def energy(numbers, coords, a, kpts, kpts_band):
@@ -169,7 +181,6 @@ def test_gfn1_kxtb_pad_energy_force_bands(setup):
         path_bands = np.sort(path_energy.real, axis=1)[:, :N_LOWEST_BANDS]
         return e, (band, pick, path_bands)
 
-    kpts_band = np.asarray([_abs_kpts(SCALED_BAND_PATH, a) for a in a_batch])
     gfn = jax.jit(jax.vmap(
         jax.value_and_grad(energy, argnums=1, has_aux=True),
         in_axes=(0, 0, 0, 0, 0)))
@@ -217,3 +228,109 @@ def test_gfn1_kxtb_pad_energy_force_bands(setup):
     for slot, isys in enumerate(perm[:n_solids]):
         assert abs(e_swap[slot] - refs[isys][0]) < 1e-6
     assert gfn._cache_size() == 1
+
+
+# Body executed under PYSCFAD_FLOATX=float32 in a subprocess (see the
+# ``run_fp32`` fixture). The padded basis/param arrays must be built *inside*
+# the float32 process so the sentinel exponents and every import-time constant
+# take their float32 values. Emits the batched energies, forces, SCF bands
+# (with the mo_mask pick, exercising the float32 padding level shift), and the
+# get_bands path for the parent to compare against the FP64 references.
+_FP32_KXTB_PAD_BODY = """
+from pyscfad.xtb import basis as xtb_basis
+from pyscfad.ml.gto import make_basis_array
+from pyscfad.ml.xtb import GFN1KXTB, make_param_array
+from pyscfad.ml.pbc.gto import CellPad
+
+numbers = np.asarray(IN["numbers"], dtype=np.int32)
+coords = np.asarray(IN["coords"])
+a_batch = np.asarray(IN["a"])
+kpts = np.asarray(IN["kpts"])
+kpts_band = np.asarray(IN["kpts_band"])
+Ts = numpy.asarray(IN["Ts"])
+ewald_mesh = numpy.asarray(IN["ewald_mesh"])
+RCUT = IN["rcut"]
+N_LOWEST_BANDS = IN["n_lowest_bands"]
+
+bfile = xtb_basis.get_basis_filename()
+basis = make_basis_array(bfile, max_number=IN["max_number"])
+param = make_param_array(basis, max_number=IN["max_number"])
+
+def energy(numbers, coords, a, kpts, kpts_band):
+    Ls = np.asarray(Ts, dtype=np.floatx) @ a
+    cell = CellPad(numbers, coords, basis=basis, a=a, Ls=Ls, rcut=RCUT,
+                   precision=1e-6, verbose=0, trace_coords=True)
+    mf = GFN1KXTB(cell, param, kpts=kpts)
+    mf.ewald_mesh = ewald_mesh
+    mf.diis = "anderson"
+    mf.conv_tol = 1e-5
+    e = mf.kernel()
+
+    band = mf.mo_energy.real
+    mask = mf.mo_mask(band)
+    nocc = mf.tot_electrons // 2
+    flat = band.ravel()
+    order = np.argsort(flat)
+    m = mask.ravel()[order]
+    pick_sorted = (np.cumsum(m) <= nocc) & m
+    pick = np.zeros_like(pick_sorted).at[order].set(
+        pick_sorted).reshape(band.shape)
+
+    path_energy, _ = mf.get_bands(kpts_band)
+    path_bands = np.sort(path_energy.real, axis=1)[:, :N_LOWEST_BANDS]
+    return e, (band, pick, path_bands)
+
+gfn = jax.jit(jax.vmap(jax.value_and_grad(energy, argnums=1, has_aux=True),
+                       in_axes=(0, 0, 0, 0, 0)))
+(e, (band, pick, path_bands)), g = gfn(numbers, coords, a_batch, kpts,
+                                       kpts_band)
+emit(e=numpy.asarray(e).tolist(),
+     g=numpy.asarray(g).tolist(),
+     band=numpy.asarray(band).tolist(),
+     pick=numpy.asarray(pick).tolist(),
+     path_bands=numpy.asarray(path_bands).tolist())
+"""
+
+
+def test_gfn1_kxtb_pad_energy_force_bands_fp32(setup, refs, run_fp32):
+    bfile, basis, param, nimgs, Ts, ewald_mesh, scaled_kpts = setup
+    nk = len(scaled_kpts)
+
+    numbers, coords, a_batch, kpts, kpts_band = _make_batch(scaled_kpts)
+    n_solids = len(SYSTEMS)
+
+    out = run_fp32(
+        _FP32_KXTB_PAD_BODY,
+        numbers=numbers, coords=coords, a=a_batch, kpts=kpts,
+        kpts_band=kpts_band, Ts=Ts, ewald_mesh=ewald_mesh, rcut=RCUT,
+        n_lowest_bands=N_LOWEST_BANDS, max_number=MAX_NUMBER,
+    )
+    e = numpy.asarray(out["e"])
+    g = numpy.asarray(out["g"])
+    band = numpy.asarray(out["band"])
+    pick = numpy.asarray(out["pick"], dtype=bool)
+    path_bands = numpy.asarray(out["path_bands"])
+
+    # float32 energy parity with the unbatched FP64 references
+    for i, (e_ref, _, _) in enumerate(refs):
+        assert abs(e[i] - e_ref) / abs(e_ref) < 2e-6
+    assert abs(e[n_solids]) < 1e-6, "empty cell energy not zero"
+
+    assert numpy.isfinite(g).all()
+    # translation invariance and point-group symmetry at float32 resolution
+    assert numpy.abs(g[:n_solids].sum(axis=1)).max() < 1e-3
+    assert numpy.abs(g[0]).max() < 1e-3
+    assert numpy.abs(g[2]).max() < 1e-3
+
+    # occupied valence bands picked through the float32 padding level shift
+    for i, (_, ref_bands, _) in enumerate(refs):
+        got = band[i][pick[i]].reshape(nk, -1)
+        assert got.shape == ref_bands.shape
+        assert numpy.abs(got - ref_bands).max() < 1e-3
+    assert pick[n_solids].sum() == 0
+
+    # get_bands parity along the fractional band path
+    for i, (_, _, ref_path) in enumerate(refs):
+        width = ref_path.shape[1]
+        assert numpy.abs(path_bands[i][:, :width] - ref_path).max() < 1e-3
+    assert numpy.isfinite(path_bands[n_solids]).all()


### PR DESCRIPTION
## Summary

Extends the molecular FP32 design (#124) to periodic GFN1-xTB with k-point sampling (`kxtb` and the batched/padded `kxtb_pad`). Integrals are still evaluated in FP64 and cast to the working precision at the boundary; all SCF arithmetic and contractions run in float32/complex64 under `PYSCFAD_FLOATX=float32`.

Previously FP32 mode ran without errors but silently promoted the periodic path back to float64/complex128: `CellLite.a`/`Ls` and `kpts` were stored as strongly-typed float64, `complex128` was hardcoded in the initial-guess density matrices, `np.zeros`/`np.eye` defaulted to float64, and the phase factor `expkL` was complex128 — so every downstream contraction (hcore/overlap einsums, Mulliken charges, eigensolver, DIIS) ran in double precision.

## Changes

- **backend/numpy.py**: add `np.complexx`, the static complex counterpart of `np.floatx` (complex64 for float32, complex128 for float64)
- **pbc/gto/cell_lite.py**: store `a` and `Ls` in the working precision (matching `MolePad`/`CellPad`); the integral wrappers recast to FP64 internally
- **pbc/scf/khf_lite.py**: store `kpts` in the working precision; build non-smearing occupations explicitly in floatx (the weak-f64 `where()` could upcast the density matrix)
- **xtb/kxtb.py**: cast the FP64 lattice overlap to floatx *before* the `expkL` einsums; `expkL` to complexx in `get_ovlp`/`get_hcore`; `h1` pinned to floatx; init-guess dm to complexx; Mulliken accumulator takes the einsum dtype; pin the gamma `np.eye` terms and the `rcut` scalar to floatx
- **ml/xtb/kxtb_pad.py**: same complexx/floatx casts in the padded path
- **scf/anderson.py**: take the real part of the residual Gram row explicitly (complex residuals arise with k-points; previously relied on an unsafe complex→real scatter cast that JAX will turn into an error)

All heavy contractions have f32/c64 operands before the contraction (verified by dtype dumps — with JAX standard promotion any f64 operand would surface in the outputs). The precision-aware thresholds (eigh `DEG_THRESH`, `padding_level_shift`, `mo_mask`) reach the PBC path unchanged through the vmapped molecular `_eigh` and the shared `SCFPad` property; complex64 `chegvd` works forward and through the JVP. The smearing mu-solve already runs in FP64 internally with its deliberate 1e-6 residual tolerance (d21cd9a4) and is unchanged.

## FP32 vs FP64 accuracy

| Case | Agreement |
|---|---|
| Si diamond 2×2×2 energy / forces | 1.7e-7 relative / 3e-8 |
| Cu with Fermi smearing | 8e-7 energy, 2e-5 forces |
| Band gap (Si path) | 1e-6 |
| Lattice-vector gradient dE/da (lattice-shift JVP) | ~1e-6 |
| Padded batch (Si + C supercell + Ne + empty cell) | <2e-6 relative, empty cell exactly 0 |

The H2O-in-box vs molecular parity (2.89e-4 energy / 4.44e-4 forces) is identical in both precisions, i.e. purely physical.

## Tests

- `test_gfn1_kxtb_energy_force_fp32` (Si + Cu smearing in one `PYSCFAD_FLOATX=float32` subprocess via the existing `run_fp32` fixture)
- `test_gfn1_kxtb_pad_energy_force_bands_fp32` (batched energies/forces/SCF bands through the float32 padding level shift, and the `get_bands` path); the FP64 references are refactored into a shared module-scoped fixture
- `np.complexx` coverage in `tests/test_floatx.py`

Full sequential sweep: `test_kxtb.py` 6 passed, `test_kxtb_pad.py` 2 passed, `test_xtb.py`/`test_xtb_pad.py`/`test_qmmm.py` 8 passed, `test_cell_lite.py` + `test_scf.py` 10 passed, `test_floatx.py` 4 passed in each precision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)